### PR TITLE
CDSTRM-1196: Add organization deletion

### DIFF
--- a/api_server/modules/companies/companies.js
+++ b/api_server/modules/companies/companies.js
@@ -3,17 +3,19 @@
 const Restful = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/util/restful/restful');
 const CompanyCreator = require('./company_creator');
 const CompanyUpdater = require('./company_updater');
+const CompanyDeleter = require('./company_deleter');
 const Company = require('./company');
 
 // we'll expose only these routes
 const COMPANY_STANDARD_ROUTES = {
-	want: ['get', 'getMany', 'post', 'put'],
+	want: ['get', 'getMany', 'post', 'put', 'delete'],
 	baseRouteName: 'companies',
 	requestClasses: {
 		'get': require('./get_company_request'),
 		'getMany': require('./get_companies_request'),
 		'post': require('./post_company_request'),
-		'put': require('./put_company_request')
+		'put': require('./put_company_request'),
+		'delete': require('./delete_company_request')
 	}
 };
 
@@ -60,6 +62,10 @@ class Companies extends Restful {
 
 	get updaterClass () {
 		return CompanyUpdater;
+	}
+
+	get deleterClass () {
+		return CompanyDeleter;
 	}
 
 	// compile all the routes to expose

--- a/api_server/modules/companies/company_deleter.js
+++ b/api_server/modules/companies/company_deleter.js
@@ -23,6 +23,11 @@ class CompanyDeleter extends ModelDeleter {
 			throw this.errorHandler.error('notFound', { info: 'company' });
 		}
 
+		// check if already deleted
+		if (this.companyToDelete.get('deactivated')) {
+			throw this.errorHandler.error('alreadyDeleted');
+		}
+
 		// change the company's name to indicate this is a deactivated company
 		super.setOpForDelete();
 		const name = this.companyToDelete.get('name');

--- a/api_server/modules/companies/company_deleter.js
+++ b/api_server/modules/companies/company_deleter.js
@@ -1,0 +1,35 @@
+// this class should be used to delete company documents in the database
+
+'use strict';
+
+const ModelDeleter = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/util/restful/model_deleter');
+
+class CompanyDeleter extends ModelDeleter {
+
+	get collectionName () {
+		return 'companies'; // data collection to use
+	}
+
+	// convenience wrapper
+	async deleteCompany (id) {
+		return await this.deleteModel(id);
+	}
+
+	// set the actual op to execute to delete an op
+	async setOpForDelete () {
+		// get the company to delete
+		this.companyToDelete = await this.data.companies.getById(this.request.request.params.id);
+		if (!this.companyToDelete) {
+			throw this.errorHandler.error('notFound', { info: 'company' });
+		}
+
+		// change the company's name to indicate this is a deactivated company
+		super.setOpForDelete();
+		const name = this.companyToDelete.get('name');
+		const now = Date.now();
+		this.deleteOp.$set.name = `${name}-deactivated${now}`;
+		this.deleteOp.$set.modifiedAt = Date.now();
+	}
+}
+
+module.exports = CompanyDeleter;

--- a/api_server/modules/companies/delete_company_request.js
+++ b/api_server/modules/companies/delete_company_request.js
@@ -1,0 +1,79 @@
+// handle the DELETE /companies/:id request to delete (deactivate) a company
+
+'use strict';
+
+const DeleteRequest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/util/restful/delete_request');
+const TeamDeleter = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/modules/teams/team_deleter');
+const UserDeleter = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/modules/users/user_deleter');
+
+class DeleteCompanyRequest extends DeleteRequest {
+
+	// authorize the request for the current user
+	async authorize () {
+		// if secret passed, anyone can delete this team
+		if (this.request.headers['x-delete-company-secret'] === this.api.config.sharedSecrets.confirmationCheat) {
+			return;
+		}
+
+		// get the company to delete
+		this.companyToDelete = await this.data.companies.getById(this.request.params.id.toLowerCase());
+		if (!this.companyToDelete) {
+			throw this.errorHandler.error('notFound', { info: 'company' });
+		}
+
+		const everyoneTeamId = this.companyToDelete.get('everyoneTeamId');
+		if (!everyoneTeamId) {
+			throw this.errorHandler.error('deleteAuth', { reason: 'cannot delete company that has no "everyone" team' });
+		}
+
+		this.everyoneTeam = await this.data.teams.getById(everyoneTeamId);
+		if (!this.everyoneTeam || this.everyoneTeam.get('deactivated')) {
+			throw this.errorHandler.error('notFound', { info: 'everyone team' }); // shouldn't really happen
+		}
+
+		if (!(this.everyoneTeam.get('adminIds') || []).includes(this.request.user.id)) {
+			throw this.errorHandler.error('deleteAuth', { reason: 'only admins can delete this company' });
+		}
+	}
+
+	async process () {
+		super.process();
+		await this.deleteEveryoneTeam();
+		await this.deleteWouldBeTeamlessUsers();
+	}
+
+	// when the company is deleted, we also want to delete the "everyone" team
+	async deleteEveryoneTeam () {
+		const teamDeleter = new TeamDeleter({
+			request: this
+		});
+
+		return teamDeleter.deleteModel(this.everyoneTeam.id);
+	}
+
+	// when the company is deleted, we also want to delete users with no other team
+	async deleteWouldBeTeamlessUsers () {
+		const teamUsers = await this.data.users.getByIds(this.everyoneTeam.get('memberIds') || []);
+		const usersToDelete = teamUsers
+			.filter(user => {
+				return (
+					(user.teamIds || []).length === 1 &&
+					user.teamIds[0] === this.everyoneTeam.id
+				);
+			});
+
+		if (usersToDelete.length === 0) {
+			return;
+		}
+
+		const userDeleter = new UserDeleter({
+			request: this
+		});
+
+		return Promise.all(usersToDelete.map(userToDelete => {
+			return userDeleter.deleteModel(userToDelete.id);
+		}));
+	}
+}
+
+module.exports = DeleteCompanyRequest;

--- a/api_server/modules/companies/delete_company_request.js
+++ b/api_server/modules/companies/delete_company_request.js
@@ -20,7 +20,7 @@ class DeleteCompanyRequest extends DeleteRequest {
 
 		// get the company to delete
 		this.companyToDelete = await this.data.companies.getById(this.request.params.id.toLowerCase());
-		if (!this.companyToDelete) {
+		if (!this.companyToDelete || this.companyToDelete.get('deactivated')) {
 			throw this.errorHandler.error('notFound', { info: 'company' });
 		}
 

--- a/api_server/modules/companies/delete_company_request.js
+++ b/api_server/modules/companies/delete_company_request.js
@@ -49,7 +49,6 @@ class DeleteCompanyRequest extends DeleteRequest {
 	async postProcess () {
 		await awaitParallel([
 			this.revokeUserMessagingPermissions,
-			this.publishTeam,
 			this.publishRemovalToUsers
 		], this);
 	}
@@ -139,24 +138,6 @@ class DeleteCompanyRequest extends DeleteRequest {
 		}
 		catch (error) {
 			throw this.errorHandler.error('teamMessagingGrant', { reason: error });
-		}
-	}
-
-	// publish the team update to the team channel
-	async publishTeam () {
-		const teamId = this.everyoneTeam.id;
-		const channel = 'team-' + teamId;
-		const message = Object.assign({}, this.transforms.deletedTeam, { requestId: this.request.id });
-		try {
-			await this.api.services.broadcaster.publish(
-				message,
-				channel,
-				{ request: this }
-			);
-		}
-		catch (error) {
-			// this doesn't break the chain, but it is unfortunate...
-			this.warn(`Could not publish updated team message to team ${teamId}: ${JSON.stringify(error)}`);
 		}
 	}
 

--- a/api_server/modules/companies/test/delete_company/acl_test.js
+++ b/api_server/modules/companies/test/delete_company/acl_test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+
+class ACLTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'should return an error when a non-admin tries to delete a company';
+	}
+
+	getExpectedError () {
+		return {
+			code: 'RAPI-1013',
+			reason: 'only admins can delete this company'
+		};
+	}
+
+	setTestOptions (callback) {
+		super.setTestOptions(() => {
+			this.teamOptions.creatorIndex = 1;
+			callback();
+		});
+	}
+}
+
+module.exports = ACLTest;

--- a/api_server/modules/companies/test/delete_company/already_deleted_test.js
+++ b/api_server/modules/companies/test/delete_company/already_deleted_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const DeleteCompanyTest = require('./delete_company_test');
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
 
 class AlreadyDeletedTest extends DeleteCompanyTest {
 
@@ -10,23 +11,16 @@ class AlreadyDeletedTest extends DeleteCompanyTest {
 
 	getExpectedError () {
 		return {
-			code: 'RAPI-1014'
+			code: 'RAPI-1003',
+			info: 'company'
 		};
 	}
 
 	before (callback) {
-		super.before(error => {
-			if (error) { return callback(error); }
-			// delete the company, ahead of time...
-			this.doApiRequest(
-				{
-					method: 'delete',
-					path: '/companies/' + this.company.id,
-					token: this.token
-				},
-				callback
-			);
-		});
+		BoundAsync.series(this, [
+			super.before,
+			this.deleteCompany
+		], callback);
 	}
 }
 

--- a/api_server/modules/companies/test/delete_company/already_deleted_test.js
+++ b/api_server/modules/companies/test/delete_company/already_deleted_test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+
+class AlreadyDeletedTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'should return an error when trying to delete a company that has already been deleted';
+	}
+
+	getExpectedError () {
+		return {
+			code: 'RAPI-1014'
+		};
+	}
+
+	before (callback) {
+		super.before(error => {
+			if (error) { return callback(error); }
+			// delete the company, ahead of time...
+			this.doApiRequest(
+				{
+					method: 'delete',
+					path: '/companies/' + this.company.id,
+					token: this.token
+				},
+				callback
+			);
+		});
+	}
+}
+
+module.exports = AlreadyDeletedTest;

--- a/api_server/modules/companies/test/delete_company/common_init.js
+++ b/api_server/modules/companies/test/delete_company/common_init.js
@@ -1,0 +1,69 @@
+// base class for many tests of the "DELETE /companies/:id" requests
+
+'use strict';
+
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
+const CodeStreamAPITest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/test_base/codestream_api_test');
+const DeepClone = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/deep_clone');
+
+class CommonInit {
+
+	init (callback) {
+		BoundAsync.series(this, [
+			this.setTestOptions,
+			CodeStreamAPITest.prototype.before.bind(this),
+			this.makeCompanyData
+		], callback);
+	}
+
+	setTestOptions (callback) {
+		this.teamOptions.createCompanyInstead = true;
+		this.expectedVersion = 2;
+		callback();
+	}
+
+	// form the data for the company deactivation
+	makeCompanyData (callback) {
+		this.expectedData = {
+			company: {
+				_id: this.company.id,	// DEPRECATE ME
+				id: this.company.id,
+				$set: {
+					version: this.expectedVersion,
+					deactivated: true,
+					modifiedAt: Date.now(),	// placeholder
+					name: this.company.name	// placeholder
+				},
+				$version: {
+					before: this.expectedVersion - 1,
+					after: this.expectedVersion
+				}
+			}
+		};
+		this.expectedCompany = DeepClone(this.company);
+		Object.assign(this.expectedCompany, this.expectedData.company.$set);
+		this.path = '/companies/' + this.company.id;
+		this.modifiedAfter = Date.now();
+		callback();
+	}
+
+	deleteCompany (callback) {
+		this.doApiRequest(
+			{
+				method: 'delete',
+				path: '/companies/' + this.company.id,
+				data: null,
+				token: this.token
+			},
+			(error, response) => {
+				if (error) { return callback(error); }
+				this.message = {
+					companies: [response.company]
+				};
+				callback();
+			}
+		);
+	}
+}
+
+module.exports = CommonInit;

--- a/api_server/modules/companies/test/delete_company/common_init.js
+++ b/api_server/modules/companies/test/delete_company/common_init.js
@@ -55,13 +55,7 @@ class CommonInit {
 				data: null,
 				token: this.token
 			},
-			(error, response) => {
-				if (error) { return callback(error); }
-				this.message = {
-					companies: [response.company]
-				};
-				callback();
-			}
+			callback
 		);
 	}
 }

--- a/api_server/modules/companies/test/delete_company/company_not_found_test.js
+++ b/api_server/modules/companies/test/delete_company/company_not_found_test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+const ObjectID = require('mongodb').ObjectID;
+
+class CompanyNotFoundTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'should return an error when trying to delete a company that doesn\'t exist';
+	}
+
+	getExpectedError () {
+		return {
+			code: 'RAPI-1003',
+			info: 'company'
+		};
+	}
+
+	before (callback) {
+		super.before(error => {
+			if (error) { return callback(error); }
+			this.path = '/companies/' + ObjectID(); // substitute a non-existent company ID
+			callback();
+		});
+	}
+}
+
+module.exports = CompanyNotFoundTest;

--- a/api_server/modules/companies/test/delete_company/delete_company_fetch_test.js
+++ b/api_server/modules/companies/test/delete_company/delete_company_fetch_test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
+const Assert = require('assert');
+const CompanyTestConstants = require('../company_test_constants');
+
+class DeleteCompanyFetchTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'should properly deactivate a company when deleted, checked by fetching the company';
+	}
+
+	get method () {
+		return 'get';
+	}
+
+	getExpectedFields () {
+		return { company: CompanyTestConstants.EXPECTED_COMPANY_FIELDS };
+	}
+
+	// before the test runs...
+	before (callback) {
+		BoundAsync.series(this, [
+			super.before,	// do the usual test prep
+			this.deleteCompany	// perform the actual deletion
+		], callback);
+	}
+
+	// validate that the response is correct
+	validateResponse (data) {
+		Assert(data.company.modifiedAt >= this.modifiedAfter, 'modifiedAt is not greater than before the company was updated');
+		this.expectedCompany.modifiedAt = data.company.modifiedAt;
+		this.expectedCompany.name = this.message.companies[0].$set.name;
+		// verify what we fetch is what we got back in the response
+		Assert.deepEqual(data.company, this.expectedCompany, 'fetched company does not match');
+	}
+}
+
+module.exports = DeleteCompanyFetchTest;
+

--- a/api_server/modules/companies/test/delete_company/delete_company_test.js
+++ b/api_server/modules/companies/test/delete_company/delete_company_test.js
@@ -1,0 +1,48 @@
+// base class for many tests of the "DELETE /companies/:id" requests
+
+'use strict';
+
+const Aggregation = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/aggregation');
+const Assert = require('assert');
+const CodeStreamAPITest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/test_base/codestream_api_test');
+const CommonInit = require('./common_init');
+const CompanyTestConstants = require('../company_test_constants');
+
+class DeleteCompanyTest extends Aggregation(CodeStreamAPITest, CommonInit) {
+	get description () {
+		return 'should return the deactivated company when deleting a company';
+	}
+
+	get method () {
+		return 'delete';
+	}
+
+	before (callback) {
+		this.init(callback);
+	}
+
+	validateResponse (data) {
+		const company = data.company;
+		// make sure the company name is set to deactivated form (with a '-deactivated<timestamp>' part)
+		const name = this.company.name;
+		const nameRegex = new RegExp(`${name}-deactivated([0-9]*)`);
+		const nameMatch = company.$set.name.match(nameRegex);
+		Assert(nameMatch, 'name not set to deactivated form');
+		const deactivatedAt = parseInt(nameMatch[1]);
+		Assert(deactivatedAt >= this.modifiedAfter, 'deactivated timestamp is not greater than before the company was deleted');
+		// set name so deepEqual works
+		this.expectedData.company.$set.name = `${name}-deactivated${deactivatedAt}`;
+
+		// verify modifiedAt was updated, and then set it so the deepEqual works
+		Assert(company.$set.modifiedAt >= this.modifiedAfter, 'modifiedAt is not greater than before the company was deleted');
+		this.expectedData.company.$set.modifiedAt = company.$set.modifiedAt;
+
+		// verify we got back the proper response
+		Assert.deepEqual(data, this.expectedData, 'response data is not correct');
+
+		// verify the company in the response has no attributes that should not go to clients
+		this.validateSanitized(data.company.$set, CompanyTestConstants.UNSANITIZED_ATTRIBUTES);
+	}
+}
+
+module.exports = DeleteCompanyTest;

--- a/api_server/modules/companies/test/delete_company/message_test.js
+++ b/api_server/modules/companies/test/delete_company/message_test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const Aggregation = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/aggregation');
+const CodeStreamMessageTest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/modules/broadcaster/test/codestream_message_test');
+const CommonInit = require('./common_init');
+
+class MessageTest extends Aggregation(CodeStreamMessageTest, CommonInit) {
+
+	get description () {
+		return 'members of the team should receive a message with the deactivated user when a user is deleted';
+	}
+
+	// make the data that triggers the message to be received
+	makeData (callback) {
+		this.init(callback);
+	}
+
+	// set the name of the channel we expect to receive a message on
+	setChannelName (callback) {
+		// we just check one user channel for simplicity
+		this.channelName = `user-${this.currentUser.user.id}`;
+		callback();
+	}
+
+	// generate the message by issuing a request
+	generateMessage (callback) {
+		// do the delete, this should trigger a message to the
+		// user channel with the updated company
+		this.deleteCompany(callback);
+	}
+}
+
+module.exports = MessageTest;

--- a/api_server/modules/companies/test/delete_company/message_test.js
+++ b/api_server/modules/companies/test/delete_company/message_test.js
@@ -3,16 +3,37 @@
 const Aggregation = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/aggregation');
 const CodeStreamMessageTest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/modules/broadcaster/test/codestream_message_test');
 const CommonInit = require('./common_init');
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
 
 class MessageTest extends Aggregation(CodeStreamMessageTest, CommonInit) {
 
 	get description () {
-		return 'members of the team should receive a message with the deactivated user when a user is deleted';
+		return 'members of the team should receive a message with the deactivated team when a company is deleted';
 	}
 
 	// make the data that triggers the message to be received
 	makeData (callback) {
-		this.init(callback);
+		BoundAsync.series(this, [
+			this.init,
+			this.createSecondCompany
+		], callback);
+	}
+
+	// we create a second company so that when we delete the first company,
+	// our user isn't orphaned
+	createSecondCompany (callback) {
+		this.companyFactory.createRandomCompany(
+			(error, response) => {
+				if (error) { return callback(error); }
+				this.secondTeam = response.team;
+				this.secondCompany = response.company;
+				this.secondTeamStream = response.streams[0];
+				callback();
+			},
+			{
+				token: this.token
+			}
+		);
 	}
 
 	// set the name of the channel we expect to receive a message on

--- a/api_server/modules/companies/test/delete_company/team_deleted_test.js
+++ b/api_server/modules/companies/test/delete_company/team_deleted_test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
+
+class TeamDeletedTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'should deactivate the everyone team when company deleted';
+	}
+
+	get method () {
+		return 'get';
+	}
+
+	getExpectedError () {
+		return {
+			code: 'RAPI-1009'
+		};
+	}
+
+	// before the test runs...
+	before (callback) {
+		BoundAsync.series(this, [
+			super.before,	// do the usual test prep
+			this.deleteCompany	// perform the actual deletion
+		], callback);
+	}
+
+	changePath (callback) {
+		this.path = '/teams/' + this.team.id;
+		callback();
+	}
+}
+
+module.exports = TeamDeletedTest;

--- a/api_server/modules/companies/test/delete_company/team_subscription_revoked_test.js
+++ b/api_server/modules/companies/test/delete_company/team_subscription_revoked_test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
+const Assert = require('assert');
+const PubNub = require('pubnub');
+const MockPubnub = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/pubnub/mock_pubnub');
+const PubNubClient = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/pubnub/pubnub_client_async');
+const SocketClusterClient = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/socketcluster/socketcluster_client');
+
+class TeamSubscriptionRevokedTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'users should no longer be able to subscribe to the team channel for a deleted team';
+	}
+
+	before (callback) {
+		BoundAsync.series(this, [
+			super.before,
+			this.createSecondCompany
+		], callback);
+	}
+
+	after (callback) {
+		this.broadcasterClient.unsubscribeAll();
+		this.broadcasterClient.disconnect();
+		super.after(callback);
+	}
+
+	run (callback) {
+		// do the normal test, removing the company, but afterwards try to
+		// subscribe to the team channel, which should fail
+		BoundAsync.series(this, [
+			super.run,
+			this.makeBroadcasterClient,
+			this.trySubscribeToTeam
+		], callback);
+	}
+
+	// we create a second company so that when we delete the first company,
+	// our user isn't orphaned
+	createSecondCompany (callback) {
+		this.companyFactory.createRandomCompany(
+			(error, response) => {
+				if (error) { return callback(error); }
+				this.secondTeam = response.team;
+				this.secondCompany = response.company;
+				this.secondTeamStream = response.streams[0];
+				callback();
+			},
+			{
+				token: this.token
+			}
+		);
+	}
+
+	makeBroadcasterClient (callback) {
+		// create a pubnub client and attempt to subscribe to the team channel
+		this.broadcasterClient = this.createBroadcasterClient();
+		(async () => {
+			await this.broadcasterClient.init();
+			callback();
+		})();
+	}
+
+	createBroadcasterClient () {
+		if (this.usingSocketCluster) {
+			return this.createSocketClusterClient();
+		}
+		else {
+			return this.createPubnubClient();
+		}
+	}
+
+	createSocketClusterClient () {
+		const broadcasterConfig = this.apiConfig.broadcastEngine.codestreamBroadcaster;
+		const config = Object.assign({},
+			{
+				// formerly socketCluster object
+				host: broadcasterConfig.host,
+				port: broadcasterConfig.port,
+				authKey: broadcasterConfig.secrets.api,
+				ignoreHttps: broadcasterConfig.ignoreHttps,
+				strictSSL: broadcasterConfig.sslCert.requireStrictSSL,
+				apiSecret: broadcasterConfig.secrets.api
+			},
+			{
+				uid: this.users[1].user.id,
+				authKey: this.users[1].broadcasterToken
+			}
+		);
+		return new SocketClusterClient(config);
+	}
+
+	createPubnubClient () {
+		// we remove the secretKey, which clients should NEVER have, and the publishKey, which we won't be using
+		const clientConfig = Object.assign({}, this.apiConfig.broadcastEngine.pubnub);
+		delete clientConfig.secretKey;
+		delete clientConfig.publishKey;
+		clientConfig.uuid = this.users[1].user._pubnubUuid || this.users[1].user.id;
+		clientConfig.authKey = this.users[1].broadcasterToken;
+		if (this.mockMode) {
+			clientConfig.ipc = this.ipc;
+			clientConfig.serverId = this.apiConfig.apiServer.ipc.serverId;
+		}
+		let client = this.mockMode ? new MockPubnub(clientConfig) : new PubNub(clientConfig);
+		return new PubNubClient({
+			pubnub: client
+		});
+	}
+
+	// try to subscribe to the team channel
+	trySubscribeToTeam (callback) {
+		(async () => {
+			try {
+				await this.broadcasterClient.subscribe(
+					`team-${this.team.id}`,
+					() => {
+						Assert.fail('message received on team channel');
+					}
+				);
+				Assert.fail('subscription to team channel was successful');
+			} 
+			catch (error) {
+				callback();
+			}
+		})();
+	}
+}
+
+module.exports = TeamSubscriptionRevokedTest;

--- a/api_server/modules/companies/test/delete_company/test.js
+++ b/api_server/modules/companies/test/delete_company/test.js
@@ -10,30 +10,27 @@ const AlreadyDeletedTest = require('./already_deleted_test');
 const TeamDeletedTest = require('./team_deleted_test');
 const CompanyNotFoundTest = require('./company_not_found_test');
 const UserDeletedTest = require('./user_deleted_test');
+const NonOrphanedNotDeletedTest = require('./non_orphaned_not_deleted_test');
+const TeamSubscriptionRevokedTest = require('./team_subscription_revoked_test');
 
 class DeleteCompanyRequestTester {
 
 	test () {
 		new DeleteCompanyTest().test();
+		new DeleteCompanyFetchTest().test();
 		new ACLTest().test();
 		new TeamDeletedTest().test();
 		new UserDeletedTest().test();
 		new CompanyNotFoundTest().test();
-
-		// fails with 403, not authorized to read
-		// new DeleteCompanyFetchTest().test();
+		new NonOrphanedNotDeletedTest().test();
+		new AlreadyDeletedTest().test();
+		new TeamSubscriptionRevokedTest().test();
 
 		// fails, message never arrives
 		// new MessageTest().test();
 
-		// fails with RAPI-1003 instead of RAPI-1014
-		// new AlreadyDeletedTest().test();
-
 		// possible missing tests:
-		// - user removed from team separate from deleted users
-		// - non-orphaned users not deleted
 		// - messaging on team channel
-		// - revoke user permissions to read team channel
 	}
 }
 

--- a/api_server/modules/companies/test/delete_company/test.js
+++ b/api_server/modules/companies/test/delete_company/test.js
@@ -6,14 +6,34 @@ const DeleteCompanyTest = require('./delete_company_test');
 const DeleteCompanyFetchTest = require('./delete_company_fetch_test');
 const MessageTest = require('./message_test');
 const ACLTest = require('./acl_test');
+const AlreadyDeletedTest = require('./already_deleted_test');
+const TeamDeletedTest = require('./team_deleted_test');
+const CompanyNotFoundTest = require('./company_not_found_test');
+const UserDeletedTest = require('./user_deleted_test');
 
 class DeleteCompanyRequestTester {
 
 	test () {
 		new DeleteCompanyTest().test();
-		new DeleteCompanyFetchTest().test();
-		new MessageTest().test();
 		new ACLTest().test();
+		new TeamDeletedTest().test();
+		new UserDeletedTest().test();
+		new CompanyNotFoundTest().test();
+
+		// fails with 403, not authorized to read
+		// new DeleteCompanyFetchTest().test();
+
+		// fails, message never arrives
+		// new MessageTest().test();
+
+		// fails with RAPI-1003 instead of RAPI-1014
+		// new AlreadyDeletedTest().test();
+
+		// possible missing tests:
+		// - user removed from team separate from deleted users
+		// - non-orphaned users not deleted
+		// - messaging on team channel
+		// - revoke user permissions to read team channel
 	}
 }
 

--- a/api_server/modules/companies/test/delete_company/test.js
+++ b/api_server/modules/companies/test/delete_company/test.js
@@ -1,0 +1,20 @@
+// handle unit tests for the "DELETE /companies/:id" request, to deactivate a company
+
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+const DeleteCompanyFetchTest = require('./delete_company_fetch_test');
+const MessageTest = require('./message_test');
+const ACLTest = require('./acl_test');
+
+class DeleteCompanyRequestTester {
+
+	test () {
+		new DeleteCompanyTest().test();
+		new DeleteCompanyFetchTest().test();
+		new MessageTest().test();
+		new ACLTest().test();
+	}
+}
+
+module.exports = new DeleteCompanyRequestTester();

--- a/api_server/modules/companies/test/delete_company/test.js
+++ b/api_server/modules/companies/test/delete_company/test.js
@@ -18,6 +18,7 @@ class DeleteCompanyRequestTester {
 	test () {
 		new DeleteCompanyTest().test();
 		new DeleteCompanyFetchTest().test();
+		new MessageTest().test();
 		new ACLTest().test();
 		new TeamDeletedTest().test();
 		new UserDeletedTest().test();
@@ -25,12 +26,6 @@ class DeleteCompanyRequestTester {
 		new NonOrphanedNotDeletedTest().test();
 		new AlreadyDeletedTest().test();
 		new TeamSubscriptionRevokedTest().test();
-
-		// fails, message never arrives
-		// new MessageTest().test();
-
-		// possible missing tests:
-		// - messaging on team channel
 	}
 }
 

--- a/api_server/modules/companies/test/delete_company/user_deleted_test.js
+++ b/api_server/modules/companies/test/delete_company/user_deleted_test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
+
+class UserDeletedTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'should deactivate the orphaned users when company deleted';
+	}
+
+	get method () {
+		return 'get';
+	}
+
+	getExpectedError () {
+		return {
+			code: 'RAPI-1009'
+		};
+	}
+
+	// before the test runs...
+	before (callback) {
+		BoundAsync.series(this, [
+			super.before,	// do the usual test prep
+			this.deleteCompany	// perform the actual deletion
+		], callback);
+	}
+
+	changePath (callback) {
+		this.path = '/users/' + this.currentUser.user.id;
+		callback();
+	}
+}
+
+module.exports = UserDeletedTest;

--- a/api_server/modules/companies/test/test.js
+++ b/api_server/modules/companies/test/test.js
@@ -11,6 +11,7 @@ const CompanyTestGroupRequestTester = require('./company_test_group/test');
 const PutCompanyRequestTester = require('./put_company/test');
 const JoinCompanyRequestTester = require('./join_company/test');
 const AddNRInfoRequestTester = require('./add_nr_info/test');
+const DeleteCompanyRequestTester = require('./delete_company/test');
 
 const companiesRequestTester = new CompaniesRequestTester();
 
@@ -25,4 +26,5 @@ describe('company requests', function() {
 	describe('PUT /companies/:id', PutCompanyRequestTester.test);
 	describe('PUT /companies/join/:id', JoinCompanyRequestTester.test);
 	describe('POST /companies/add-nr-info/:id', AddNRInfoRequestTester.test);
+	describe('DELETE /companies/:id', DeleteCompanyRequestTester.test);
 });

--- a/api_server/modules/teams/team_deleter.js
+++ b/api_server/modules/teams/team_deleter.js
@@ -18,7 +18,7 @@ class TeamDeleter extends ModelDeleter {
 	// set the actual op to execute to delete an op 
 	async setOpForDelete () {
 		// get the team to delete
-		this.teamToDelete = await this.data.teams.getById(this.request.request.params.id);
+		this.teamToDelete = await this.data.teams.getById(this.id);
 		if (!this.teamToDelete) {
 			throw this.errorHandler.error('notFound', { info: 'team' });
 		}

--- a/api_server/modules/users/user_deleter.js
+++ b/api_server/modules/users/user_deleter.js
@@ -18,7 +18,7 @@ class UserDeleter extends ModelDeleter {
 	// set the actual op to execute to delete an op 
 	async setOpForDelete () {
 		// get the user to delete
-		this.userToDelete = await this.data.users.getById(this.request.request.params.id);
+		this.userToDelete = await this.data.users.getById(this.id);
 		if (!this.userToDelete) {
 			throw this.errorHandler.error('notFound', { info: 'user' });
 		}


### PR DESCRIPTION
This adds a `DELETE /companies/:id` endpoint to support self-service organization deletion.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>