### PR TITLE
CDSTRM-1316: Add registration via NR

### DIFF
--- a/api_server/modules/users/errors.js
+++ b/api_server/modules/users/errors.js
@@ -142,5 +142,10 @@ module.exports = {
 		code: 'USRC-1026',
 		message: 'Webmail email addresses need to be confirmed',
 		description: 'The user tried to register using a webmail email address, but we need to make sure they really want to do this, rather than using a domain address'
+	},
+	'failedToFetchNRData': {
+		code: 'USRC-1027',
+		message: 'Could not fetch required data from New Relic',
+		description: 'The user tried to register using a New Relic API key, but we were unable to fetch the required data from the server'
 	}
 };

--- a/api_server/modules/users/nr_register_request.js
+++ b/api_server/modules/users/nr_register_request.js
@@ -1,0 +1,182 @@
+// handle the "POST /no-auth/nr-register" request to register a new user via
+// New Relic API key
+
+'use strict';
+
+const UserCreator = require('./user_creator');
+const ConfirmHelper = require('./confirm_helper');
+const Indexes = require('./indexes');
+const Errors = require('./errors');
+const AuthErrors = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/modules/authenticator/errors');
+const RestfulRequest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/util/restful/restful_request.js');
+const GraphQLClient = require('graphql-client');
+
+class NRRegisterRequest extends RestfulRequest {
+
+	constructor (options) {
+		super(options);
+		this.errorHandler.add(Errors);
+		this.errorHandler.add(AuthErrors);
+	}
+
+	// authorization happens via New Relic in the process phase
+	async authorize () {
+	}
+
+	async process () {
+		await this.requireAndAllow();	// set request parameters
+		await this.getNewRelicUser();	// fetches the email and full name for the user from New Relic
+		await this.getExistingUser();	// check if a user already exists for the email address
+		await this.saveUser();			// create the user in the database
+		await this.doLogin();			// log the user in
+	}
+
+	// require certain parameters, discard unknown parameters
+	async requireAndAllow () {
+		await this.requireAllowParameters(
+			'body',
+			{
+				required: {
+					string: ['apiKey']
+				},
+				optional: {
+					string: ['apiRegion']
+				}
+			}
+		);
+	}
+
+	// fetches the email and full name for the user from New Relic
+	async getNewRelicUser () {
+		try {
+			let response;
+			// check if we should use fake data from headers
+			response = await this.checkHeaderSecrets();
+			if (!response) {
+				// TODO: consider a better way to do this
+				const baseUrl = this.request.body.apiRegion === 'eu' ? 'https://api.eu.newrelic.com/graphql' : 'https://api.newrelic.com/graphql';
+				const client = GraphQLClient({
+					url: baseUrl,
+					headers: {
+						'Api-Key': this.request.body.apiKey,
+						'Content-Type': 'application/json',
+						'NewRelic-Requesting-Services': 'CodeStream'
+					}
+				});
+
+				response = await client.query(`{
+					actor {
+						user {
+							email
+							name
+						}
+					}
+				}`);
+			}
+			if (response.errors) {
+				throw response.errors.map(error => error.message).join(', ');
+			}
+			if (!response.data || !response.data.actor || !response.data.actor.user || !response.data.actor.user.email) {
+				throw 'Did not retrieve email address from New Relic';
+			}
+			const email = response.data.actor.user.email;
+			const username = email.split('@')[0].replace(/\+/g, '');
+			const fullName = (
+				response.data &&
+				response.data.actor &&
+				response.data.actor.user &&
+				response.data.actor.user.name
+			);
+			this.userData = {
+				email,
+				fullName,
+				username
+			};
+		} catch (error) {
+			throw this.errorHandler.error('failedToFetchNRData', { reason: error });
+		}
+	}
+
+	// check whether we should fake fetching data from NR
+	async checkHeaderSecrets () {
+		// TODO: use a more appropriate secret for this
+		const secretsList = (this.api.config.sharedSecrets.commentEngineSecrets || []);
+		// TODO: handle case where secretsList is empty
+		const { headers } = this.request;
+		if (secretsList.includes(headers['x-cs-newrelic-secret']) && headers['x-cs-mock-email']) {
+			this.warn('Secret provided to use mock NR user data, this had better be a test!');
+			return {
+				data: {
+					actor: {
+						user: {
+							email: headers['x-cs-mock-email'],
+							name: headers['x-cs-mock-name']
+						}
+					}
+				}
+			};
+		}
+	}
+
+	// check if a user already exists for the email address
+	async getExistingUser () {
+		this.user = await this.data.users.getOneByQuery(
+			{ searchableEmail: this.userData.email.toLowerCase() },
+			{ hint: Indexes.bySearchableEmail }
+		);
+		if (this.user) {
+			throw this.errorHandler.error('alreadyRegistered');
+		}
+	}
+
+	// create the user in the database
+	async saveUser () {
+		this.userCreator = new UserCreator({
+			request: this,
+		});
+		this.user = await this.userCreator.createUser(this.userData);
+	}
+
+	// mark the user as registered and log them in
+	async doLogin () {
+		this.responseData = await new ConfirmHelper({
+			request: this,
+			user: this.user
+		}).confirm(this.userData);
+	}
+
+	// describe this route for help
+	static describe () {
+		return {
+			tag: 'nr-register',
+			summary: 'Registers a user via New Relic',
+			access: 'No authorization needed',
+			description: 'Registers a user for the email address retrieved via a New Relic API key; this will create a new user record if a user with that email doesn\'t already exist, or it will return the user record for a user if a user with that email does exist and is not yet confirmed.',
+			input: {
+				summary: 'Specify attributes in the body',
+				looksLike: {
+					'apiKey*': '<New Relic API key used to retrieve user information>',
+					'apiRegion': '<New Relic region to query against>',
+				}
+			},
+			returns: {
+				summary: 'Returns a user object',
+				looksLike: {
+					user: '<@@#user object#user@@>'
+				}
+			},
+			errors: [
+				'parameterRequired',
+				'exists',
+				'validation',
+				'failedToFetchNRData',
+				'tokenExpired',
+				'alreadyRegistered',
+				'notFound',
+				'createAuth'
+			]
+		};
+	}
+}
+
+module.exports = NRRegisterRequest;

--- a/api_server/modules/users/test/nr_registration/already_registered_email_test.js
+++ b/api_server/modules/users/test/nr_registration/already_registered_email_test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const CodeStreamAPITest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/test_base/codestream_api_test');
+
+class AlreadyRegisteredEmailTest extends CodeStreamAPITest {
+
+	get description () {
+		return 'should return an error when a user already exists with that email';
+	}
+
+	get method () {
+		return 'post';
+	}
+
+	get path () {
+		return '/no-auth/nr-register';
+	}
+
+	getExpectedFields () {
+		return null;
+	}
+
+	getExpectedError () {
+		return {
+			code: 'USRC-1006',
+			message: 'This user is already registered and confirmed'
+		};
+	}
+
+	before (callback) {
+		super.before(error => {
+			if (error) { return callback(error); }
+			this.data = {
+				apiKey: 'dummy'
+			};
+			this.apiRequestOptions = {
+				headers: {
+					// TODO: use more appropriate secret
+					'X-CS-NewRelic-Secret': this.apiConfig.sharedSecrets.commentEngine,
+					'X-CS-Mock-Email': this.currentUser.user.email,
+					'X-CS-Mock-Name': this.currentUser.user.fullName
+				}
+			};
+			this.ignoreTokenOnRequest = true;
+			callback();
+		});
+	}
+}
+
+module.exports = AlreadyRegisteredEmailTest;

--- a/api_server/modules/users/test/nr_registration/bad_api_key_test.js
+++ b/api_server/modules/users/test/nr_registration/bad_api_key_test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const CodeStreamAPITest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/test_base/codestream_api_test');
+
+class BadApiKeyTest extends CodeStreamAPITest {
+
+	get description () {
+		return 'should return an error when a bad api key is used';
+	}
+
+	get method () {
+		return 'post';
+	}
+
+	get path () {
+		return '/no-auth/nr-register';
+	}
+
+	getExpectedFields () {
+		return null;
+	}
+
+	getExpectedError () {
+		return {
+			code: 'USRC-1027',
+			message: 'Could not fetch required data from New Relic',
+			reason: 'Bad API Key or no API Key provided'	// comes from New Relic
+		};
+	}
+
+	before (callback) {
+		super.before(error => {
+			if (error) { return callback(error); }
+			this.data = {
+				apiKey: 'dummy'
+			};
+			callback();
+		});
+	}
+}
+
+module.exports = BadApiKeyTest;

--- a/api_server/modules/users/test/nr_registration/eu_api_test.js
+++ b/api_server/modules/users/test/nr_registration/eu_api_test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const NRRegistrationTest = require('./nr_registration_test');
+
+class EuApiTest extends NRRegistrationTest {
+	
+	before (callback) {
+		super.before(error => {
+			if (error) { return callback(error); }
+			this.data.apiRegion = 'eu';
+			this.expectedUserData.providerInfo.newrelic.data.apiUrl = 'https://api.eu.newrelic.com';
+			callback();
+		});
+	}
+}
+
+module.exports = EuApiTest;

--- a/api_server/modules/users/test/nr_registration/no_api_key_test.js
+++ b/api_server/modules/users/test/nr_registration/no_api_key_test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const CodeStreamAPITest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/test_base/codestream_api_test');
+
+class NoApiKeyTest extends CodeStreamAPITest {
+
+	get description () {
+		return 'should return an error when no api key is provided';
+	}
+
+	get method () {
+		return 'post';
+	}
+
+	get path () {
+		return '/no-auth/nr-register';
+	}
+
+	getExpectedFields () {
+		return null;
+	}
+
+	getExpectedError () {
+		return {
+			code: 'RAPI-1001',
+			message: 'Parameter required',
+			info: 'apiKey'
+		};
+	}
+}
+
+module.exports = NoApiKeyTest;

--- a/api_server/modules/users/test/nr_registration/nr_registration_test.js
+++ b/api_server/modules/users/test/nr_registration/nr_registration_test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const Assert = require('assert');
+const CodeStreamAPITest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/test_base/codestream_api_test');
+const UserTestConstants = require('../user_test_constants');
+
+class NRRegistrationTest extends CodeStreamAPITest {
+
+	get description () {
+		return 'should return valid user data when registering';
+	}
+
+	get method () {
+		return 'post';
+	}
+
+	get path () {
+		return '/no-auth/nr-register';
+	}
+
+	/*
+	getExpectedFields () {
+		const expectedResponse = { ...UserTestConstants.EXPECTED_LOGIN_RESPONSE };
+		if (this.usingSocketCluster) {
+			delete expectedResponse.pubnubKey;
+			delete expectedResponse.pubnubToken;
+		}
+		return expectedResponse;
+	}
+	*/
+
+	// before the test runs...
+	before (callback) {
+		super.before(error => {
+			if (error) { return callback(error); }
+			this.expectedUserData = this.userFactory.randomNamedUser();
+			this.data = {
+				apiKey: 'dummy'
+			};
+			this.apiRequestOptions = {
+				headers: {
+					// TODO: use more appropriate secret
+					'X-CS-NewRelic-Secret': this.apiConfig.sharedSecrets.commentEngine,
+					'X-CS-Mock-Email': this.expectedUserData.email,
+					'X-CS-Mock-Name': this.expectedUserData.fullName
+				}
+			};
+			this.ignoreTokenOnRequest = true;
+			this.expectedVersion = 1;
+			callback();
+		});
+	}
+
+	/* eslint complexity: 0 */
+	validateResponse (data) {
+		let user = data.user;
+		let errors = [];
+		(user.secondaryEmails || []).sort();
+		(this.data.secondaryEmails || []).sort();
+		const email = this.expectedUserData.email.trim();
+		const username = email.split('@')[0].replace(/\+/g, '');
+		let result = (
+			((user.id === user._id) || errors.push('id not set to _id')) && 	// DEPRECATE ME
+			((user.email === email) || errors.push('incorrect email')) &&
+			((JSON.stringify(user.secondaryEmails) === JSON.stringify(this.data.secondaryEmails)) || errors.push('secondaryEmails does not natch')) &&
+			((user.username === username) || errors.push('incorrect username')) &&
+			((user.fullName === this.expectedUserData.fullName) || errors.push('incorrect full name')) &&
+			((user.timeZone === this.data.timeZone) || errors.push('incorrect time zone')) &&
+			((user.deactivated === false) || errors.push('deactivated not false')) &&
+			((typeof user.createdAt === 'number') || errors.push('createdAt not number')) &&
+			((user.modifiedAt >= user.createdAt) || errors.push('modifiedAt not greater than or equal to createdAt')) &&
+			((user.creatorId === (this.expectedCreatorId || user.id).toString()) || errors.push('creatorId not equal to id')) &&
+			((user.phoneNumber === '') || errors.push('phoneNumber not set to default of empty string')) &&
+			((user.iWorkOn === '') || errors.push('iWorkOn not set to default value of empty string')) &&
+			((user.version === this.expectedVersion) || errors.push('version is not correct'))
+		);
+		Assert(result === true && errors.length === 0, 'response not valid: ' + errors.join(', '));
+		Assert.deepEqual(user.providerIdentities, [], 'providerIdentities is not an empty array');
+		// verify we got no attributes that clients shouldn't see
+		this.validateSanitized(user, UserTestConstants.UNSANITIZED_ATTRIBUTES_FOR_ME);
+	}
+}
+
+module.exports = NRRegistrationTest;

--- a/api_server/modules/users/test/nr_registration/test.js
+++ b/api_server/modules/users/test/nr_registration/test.js
@@ -1,0 +1,20 @@
+// handle unit tests for the "POST /no-auth/nr-register" request to register a
+// user via NR API key
+'use strict';
+
+const AlreadyRegisteredEmailTest = require('./already_registered_email_test');
+const BadApiKeyTest = require('./bad_api_key_test');
+const NoApiKeyTest = require('./no_api_key_test');
+const NRRegistrationTest = require('./nr_registration_test');
+
+class NRRegistrationRequestTester {
+
+	test () {
+		new NRRegistrationTest().test();
+		new NoApiKeyTest().test();
+		new BadApiKeyTest().test();
+		new AlreadyRegisteredEmailTest().test();
+	}
+}
+
+module.exports = new NRRegistrationRequestTester();

--- a/api_server/modules/users/test/nr_registration/test.js
+++ b/api_server/modules/users/test/nr_registration/test.js
@@ -4,6 +4,7 @@
 
 const AlreadyRegisteredEmailTest = require('./already_registered_email_test');
 const BadApiKeyTest = require('./bad_api_key_test');
+const EuApiTest = require('./eu_api_test');
 const NoApiKeyTest = require('./no_api_key_test');
 const NRRegistrationTest = require('./nr_registration_test');
 
@@ -14,6 +15,7 @@ class NRRegistrationRequestTester {
 		new NoApiKeyTest().test();
 		new BadApiKeyTest().test();
 		new AlreadyRegisteredEmailTest().test();
+		new EuApiTest().test();
 	}
 }
 

--- a/api_server/modules/users/test/test.js
+++ b/api_server/modules/users/test/test.js
@@ -20,6 +20,7 @@ const GitLensUserRequestTester = require('./gitlens_user/test');
 const ReadItemRequestTester = require('./read_item/test');
 const UnsubscribeWeeklyRequestTester = require('./unsubscribe_weekly/test');
 const GetSignupJWTRequestTester = require('./get_signup_jwt/test');
+const NRRegistrationRequestTester = require('./nr_registration/test');
 
 const userRequestTester = new UserRequestTester();
 
@@ -54,4 +55,5 @@ describe('user requests', function() {
 	describe('PUT /read-item/:postId', ReadItemRequestTester.test);
 	describe('GET /no-auth/unsubscribe-weekly', UnsubscribeWeeklyRequestTester.test);
 	describe('GET /signup-jwt', GetSignupJWTRequestTester.test);
+	describe('POST /no-auth/nr-register', NRRegistrationRequestTester.test);
 });

--- a/api_server/modules/users/users.js
+++ b/api_server/modules/users/users.js
@@ -39,6 +39,11 @@ const USERS_ADDITIONAL_ROUTES = [
 	},
 	{
 		method: 'post',
+		path: 'no-auth/nr-register',
+		requestClass: require('./nr_register_request')
+	},
+	{
+		method: 'post',
 		path: 'no-auth/confirm',
 		requestClass: require('./confirm_request')
 	},


### PR DESCRIPTION
This adds a `POST /no-auth/nr-register` endpoint to support registering via a New Relic API key.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>