### PR TITLE
CDSTRM-1316: Pass email when user exists

### DIFF
--- a/api_server/modules/users/nr_register_request.js
+++ b/api_server/modules/users/nr_register_request.js
@@ -150,7 +150,7 @@ class NRRegisterRequest extends RestfulRequest {
 			{ hint: Indexes.bySearchableEmail }
 		);
 		if (this.user) {
-			throw this.errorHandler.error('alreadyRegistered');
+			throw this.errorHandler.error('alreadyRegistered', { info: this.userData.email });
 		}
 	}
 

--- a/api_server/modules/users/test/nr_registration/already_registered_email_test.js
+++ b/api_server/modules/users/test/nr_registration/already_registered_email_test.js
@@ -23,7 +23,8 @@ class AlreadyRegisteredEmailTest extends CodeStreamAPITest {
 	getExpectedError () {
 		return {
 			code: 'USRC-1006',
-			message: 'This user is already registered and confirmed'
+			message: 'This user is already registered and confirmed',
+			info: this.currentUser.user.email
 		};
 	}
 


### PR DESCRIPTION
This modifies the `/no-auth/nr-register` endpoint to pass along the email of the user when attempting to register for a user whose email is already in use.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>