### PR TITLE
CDSTRM-1321: Add login by code to web

### DIFF
--- a/api_server/modules/users/login_code_helper.js
+++ b/api_server/modules/users/login_code_helper.js
@@ -1,0 +1,97 @@
+// provides a set of common routines for generating login codes
+
+'use strict';
+
+const ConfirmCode = require('./confirm_code');
+const Indexes = require('./indexes');
+
+class LoginCodeHelper {
+
+	constructor (options) {
+		Object.assign(this, options);
+	}
+
+	// generate and store a login code for a given user email
+	async updateUserCode () {
+		if (!this.email) {
+			throw this.request.errorHandler.error('parameterRequired', { info: 'email' });
+		}
+		await this.getUser();
+		await this.generateLoginCode();
+		await this.updateUser();
+		return {
+			loginCode: this.loginCode,
+			loginCodeAttempts: this.loginCodeAttempts,
+			loginCodeExpiresAt: this.loginCodeExpiresAt
+		};
+	}
+
+	// fetch the user object for the requested email address
+	async getUser () {
+		this.user = await this.request.data.users.getOneByQuery(
+			{ searchableEmail: this.email.toLowerCase() },
+			{ hint: Indexes.bySearchableEmail }
+		);
+	}
+
+	// generate a login code and expiry date
+	async generateLoginCode () {
+		if (!this.user) {
+			return;
+		}
+
+		this.loginCode = ConfirmCode();
+		// FIXME: this should be configurable
+		const expiresIn = 15*60*1000;
+		if (this.expiresIn && this.expiresIn < expiresIn) {
+			this.loginCodeExpiresAt = Date.now() + this.expiresIn;
+		}
+		else {
+			this.loginCodeExpiresAt = Date.now() + expiresIn;
+		}
+		this.loginCodeAttempts = 0;
+	}
+
+	// write the model to the user database
+	async updateUser () {
+		if (!this.user) {
+			return;
+		}
+
+		const op = {
+			$set: {
+				loginCode: this.loginCode,
+				loginCodeExpiresAt: this.loginCodeExpiresAt,
+				loginCodeAttempts: this.loginCodeAttempts,
+			},
+		};
+		this.request.data.users.applyOpById(this.user.id, op);
+	}
+
+	// send the email with the login code
+	async sendEmail () {
+		if (!this.user) {
+			return;
+		}
+		if (this._delayEmail) {
+			setTimeout(this.sendEmail.bind(this), this._delayEmail);
+			delete this._delayEmail;
+			return;
+		}
+
+		this.request.log(`Triggering email with login code to ${this.user.get('email')}...`);
+		await this.request.api.services.email.queueEmailSend(
+			{
+				type: 'loginCode',
+				userId: this.user.id,
+			},
+			{
+				request: this.request,
+				user: this.user,
+			}
+		);
+	}
+
+}
+
+module.exports = LoginCodeHelper;

--- a/api_server/modules/web/errors.js
+++ b/api_server/modules/web/errors.js
@@ -42,5 +42,17 @@ module.exports = {
 	'noUser': {
 		code: 'SWEB-1009',
 		message: 'No user can be associated with this authorization flow'
+	},
+	'loginCodeMismatch': {
+		code: 'SWEB-1010',
+		message: 'Sorry, you entered an incorrect login code.'
+	},
+	'loginCodeExpired': {
+		code: 'SWEB-1011',
+		message: 'Sorry, that login code has expired.'
+	},
+	'tooManyLoginCodeAttempts': {
+		code: 'SWEB-1012',
+		message: 'Sorry, you have made too many attempts to log in via code. You must obtain a new login code.'
 	}
 };

--- a/api_server/modules/web/styles/web.css
+++ b/api_server/modules/web/styles/web.css
@@ -727,6 +727,9 @@ span.dropdown-item:hover {
 	text-align: center;
 }
 .form-control {
+	border: 1px solid #383838 !important;
+}
+.btn-light.form-control {
 	border: 1px solid rgb(227, 228, 228) !important;
 }
 .lines-added {

--- a/api_server/modules/web/templates/confirm_code.hbs
+++ b/api_server/modules/web/templates/confirm_code.hbs
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>CodeStream</title>
+	{{> partial_html_head partial_html_head_model}}
+		 <script type="text/javascript">
+		!function () {
+			var analytics = window.analytics = window.analytics || []; if (!analytics.initialize) if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice."); else {
+				analytics.invoked = !0; analytics.methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on"]; analytics.factory = function (t) { return function () { var e = Array.prototype.slice.call(arguments); e.unshift(t); analytics.push(e); return analytics } }; for (var t = 0; t < analytics.methods.length; t++) { var e = analytics.methods[t]; analytics[e] = analytics.factory(e) } analytics.load = function (t, e) { var n = document.createElement("script"); n.type = "text/javascript"; n.async = !0; n.src = "https://cdn.segment.com/analytics.js/v1/" + t + "/analytics.min.js"; var a = document.getElementsByTagName("script")[0]; a.parentNode.insertBefore(n, a); analytics._loadOptions = e }; analytics.SNIPPET_VERSION = "4.1.0";
+				analytics.load("{{segmentKey}}");
+				analytics.page();
+			}
+		}();
+	</script>
+</head>
+
+<body>
+	<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<a class="navbar-brand" href="https://codestream.com">
+			<img alt="CodeStream" class="logo" src="https://images.codestream.com/logos/cs-banner-1764x272.png" />
+		</a>
+	</nav>
+	<div class="container mt-5">
+		<div class="row">
+			<!--<div class="col-sm-6 offset-sm-3">-->
+			<div class="col-sm-6 offset-sm-3 col-xs-6 offset-xs-3 col-md-6 offset-md-3 col-lg-4 offset-lg-4">
+				<h1 class="text-center">Check Your Email</h1>
+				<p>Please check your email. We've sent you a 6-digit code to confirm your email address.</p>
+				<p><strong>{{email}}</strong> not correct? <a href="{{changeItLink}}">Change it</a></p>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-sm-6 offset-sm-3 col-xs-6 offset-xs-3 col-md-6 offset-md-3 col-lg-4 offset-lg-4">
+				<div class="box-content box-border">
+					<form action="/web/signin-code" method="post">
+						<div class="form-group">
+							<div class="error text-center" style="width:100%">
+								{{error}}
+							</div>
+							<input type="hidden" name="finishUrl" value="{{finishUrl}}">
+							<input type="hidden" name="src" value="{{src}}">
+							<input type="hidden" name="teamId" value="{{teamId}}" />
+							<input type="hidden" name="_csrf" value="{{csrf}}" />
+							<input type="hidden" name="tenantId" value="{{tenantId}}" />
+							<input type="hidden" name="email" value="{{email}}" />
+							<div class="form-group">
+								<label for="code">Code</label>
+								<input autocomplete="off" class="form-control bg-dark" type="text" name="code" id="code" />
+							</div>
+							<div class="form-group">
+								<button type="submit" class="btn">
+									<span class="copy">Submit</span>
+								</button>
+							</div>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/api_server/modules/web/templates/login.hbs
+++ b/api_server/modules/web/templates/login.hbs
@@ -31,7 +31,11 @@
 		<div class="row">
 			<div class="col-sm-6 offset-sm-3 col-xs-6 offset-xs-3 col-md-6 offset-md-3 col-lg-4 offset-lg-4">
 				<div class="box-content box-border">
-					<form action="/web/signin" method="post">					
+					{{#if usePassword}}
+					<form action="/web/signin" method="post">
+					{{else}}
+					<form action="/web/login-code" method="post">
+					{{/if}}
 						<div class="form-group">
 								{{#if error}}
 								<div class="error text-center" style="width:100%;">
@@ -48,11 +52,13 @@
 									<input class="form-control bg-dark" type="text" name="email" id="email"
 										value="{{email}}" />
 								</div>
+								{{#if usePassword}}
 								<div class="form-group">
 									<label for="password">Password</label>
 									<input autocomplete="off" class="form-control bg-dark" type="password" name="password"
 										id="password" />
 								</div>
+								{{/if}}
 								<div class="form-group">
 									<button type="submit" class="btn btn-with-icon">
 										<span class="icon float-left">
@@ -68,6 +74,11 @@
 								</div>
 							</div>
 					</form>
+					{{#if usePassword}}
+					<p>No password? <a href="{{passwordSwitchLink}}">Sign in with a code instead.</a></p>
+					{{else}}
+					<p>We'll email you a code so you can sign in without a password. Or, <a href="{{passwordSwitchLink}}">you can sign in manually.</a></p>
+					{{/if}}
 				</div>
 			</div>
 		</div>

--- a/api_server/modules/web/web.js
+++ b/api_server/modules/web/web.js
@@ -83,8 +83,23 @@ const ROUTES = [
 	},
 	{
 		method: 'post',
+		path: 'web/login-code',
+		requestClass: require('./web_login_code_request')
+	},
+	{
+		method: 'get',
+		path: 'web/confirm-code',
+		requestClass: require('./web_confirm_code_request')
+	},
+	{
+		method: 'post',
 		path: 'web/signin',
 		requestClass: require('./web_signin_request')
+	},
+	{
+		method: 'post',
+		path: 'web/signin-code',
+		requestClass: require('./web_signin_code_request')
 	},
 	{
 		method: 'get',

--- a/api_server/modules/web/web_confirm_code_request.js
+++ b/api_server/modules/web/web_confirm_code_request.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const APIRequest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/api_server/api_request.js');
+const WebErrors = require('./errors');
+const Handlebars = require('handlebars');
+
+class WebConfirmCodeRequest extends APIRequest {
+
+	async authorize () {
+		// no authorization needed
+	}
+
+	async process () {
+		const csrf = this.request.csrfToken();
+		const email = this.request.query.email ? decodeURIComponent(this.request.query.email) : '';
+		const teamId = this.request.query.teamId ? this.request.query.teamId.toLowerCase() : '';
+		const error = this.request.query.error ? this.handleError() : '';
+		const finishUrl = decodeURIComponent(this.request.query.url || '');
+		const tenantId = decodeURIComponent(this.request.query.tenantId || '');
+		const src = decodeURIComponent(this.request.query.src || '');
+		const changeItQueryKeys = [ 'email', 'teamId', 'finishUrl', 'tenantId', 'src' ];
+		const changeItQuery = changeItQueryKeys.reduce((value, key) => {
+			if (this.request.query[key]) {
+				return value + '&' + encodeURIComponent(key) + '=' + encodeURIComponent(this.request.query[key]);
+			} else {
+				return value;
+			}
+		}, '');
+		const changeItLink = `/web/login?${changeItQuery}`;
+		this.module.evalTemplate(this, 'confirm_code', {
+			csrf,
+			email,
+			teamId,
+			error,
+			finishUrl,
+			tenantId,
+			src,
+			changeItLink
+		});
+	}
+
+	handleError () {
+		const { error, errorData } = this.request.query;
+		const webError = Object.keys(WebErrors).find(errorType => WebErrors[errorType].code === error);
+		const message = webError ? WebErrors[webError].message : WebErrors.internalError.message;
+		const template = Handlebars.compile(message);
+		let messageData = {};
+		if (errorData) {
+			try {
+				messageData = JSON.parse(decodeURIComponent(errorData));
+			}
+			catch (error) {
+				const message = error instanceof Error ? error.message : JSON.stringify(error);
+				this.warn(`Unable to parse incoming errorData: ${message}`);
+			}
+		}
+		return template(messageData);
+	}
+}
+
+module.exports = WebConfirmCodeRequest;

--- a/api_server/modules/web/web_login_code_request.js
+++ b/api_server/modules/web/web_login_code_request.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const APIRequest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/api_server/api_request.js');
+const LoginCodeHelper = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/modules/users/login_code_helper');
+const WebErrors = require('./errors');
+
+class WebLoginCodeRequest extends APIRequest {
+
+	async authorize () {
+		// no authorization needed
+	}
+
+	async process () {
+		const { email } = this.request.body;
+		if (!email) {
+			return this.loginError();
+		}
+
+		try {
+			this.loginCodeHelper = new LoginCodeHelper({
+				request: this,
+				email: email
+			});
+			await this.loginCodeHelper.updateUserCode();
+		} catch (error) {
+			return this.loginError();
+		}
+		this.finishFlow();
+	}
+
+	async postProcess () {
+		this.loginCodeHelper.sendEmail();
+	}
+
+	finishFlow () {
+		const keys = [ 'email', 'finishUrl', 'src', 'teamId', 'tenantId' ];
+		//const urlParams = keys.map(key => encodeURIComponent(key) + '=' + encodeURIComponent(passwordSwitchLinkQueryObj[key]))
+		const urlParams = keys.reduce((value, key) => {
+			if (this.request.body[key]) {
+				return value + '&' + encodeURIComponent(key) + '=' + encodeURIComponent(this.request.body[key]);
+			} else {
+				return value;
+			}
+		}, '');
+		const url = `/web/confirm-code?${urlParams}`;
+		this.response.redirect(url);
+		this.responseHandled = true;
+	}
+
+	loginError () {
+		const error = WebErrors.invalidLogin.code;
+		const email = encodeURIComponent(this.request.body.email || '');
+		const url = encodeURIComponent(this.request.body.finishUrl || '');
+		let redirect = `/web/login?error=${error}&email=${email}&url=${url}`;
+		if (this.request.body.tenantId) {
+			redirect += '&tenantId=' + encodeURIComponent(this.request.body.tenantId || '');
+		}
+		if (this.request.body.src) {
+			redirect += '&src=' + encodeURIComponent(this.request.body.src || '');
+		}
+		this.response.redirect(redirect);
+		this.responseHandled = true;
+	}
+
+}
+
+module.exports = WebLoginCodeRequest;

--- a/api_server/modules/web/web_login_request.js
+++ b/api_server/modules/web/web_login_request.js
@@ -13,6 +13,7 @@ class WebLoginRequest extends APIRequest {
 
 	async process () {
 		const csrf = this.request.csrfToken();
+		const usePassword = this.request.query.password === 'true' ? true : false;
 		const email = this.request.query.email ? decodeURIComponent(this.request.query.email) : '';
 		const teamId = this.request.query.teamId ? this.request.query.teamId.toLowerCase() : '';
 		const error = this.request.query.error ? this.handleError() : '';
@@ -37,10 +38,20 @@ class WebLoginRequest extends APIRequest {
 		});
 		const oktaLink = `/web/configure-okta?url=${finishUrl}`;
 		const oktaEnabled = !!this.api.config.integrations.okta.appClientId;
+		const passwordSwitchLinkQueryObj = {
+			...this.request.query,
+			password: !usePassword
+		};
+		const passwordSwitchLinkQuery = Object.keys(passwordSwitchLinkQueryObj)
+			.map(key => encodeURIComponent(key) + '=' + encodeURIComponent(passwordSwitchLinkQueryObj[key]))
+			.join('&');
+		const passwordSwitchLink = `/web/login?${passwordSwitchLinkQuery}`;
 		this.module.evalTemplate(this, 'login', { 
 			error,
 			email,
 			teamId,
+			usePassword,
+			passwordSwitchLink,
 			finishUrl: finishUrl,
 			tenantId:  tenantId,
 			version: this.module.versionInfo(),

--- a/api_server/modules/web/web_signin_code_request.js
+++ b/api_server/modules/web/web_signin_code_request.js
@@ -5,30 +5,36 @@ const LoginCore = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/modules/
 const SigninFlowUtils = require('./signin_flow_utils');
 const WebErrors = require('./errors');
 
-class WebSigninRequest extends APIRequest {
+class WebSigninCodeRequest extends APIRequest {
 
 	async authorize () {
 		// no authorization needed
 	}
 
 	async process () {
-		const { email, password } = this.request.body;
-		if (!email || !password) {
+		const { email, code } = this.request.body;
+		if (!email || !code) {
 			return this.loginError();
 		}
 
-		// attempt to login with email and password, and fetch the user
+		// LoginCore expects errorHandler to exist, so we fake it
+		this.errorHandler = {
+			error: error => error
+		};
+
+		// attempt to login with email and code, and fetch the user
 		try {
 			this.user = await new LoginCore({
 				request: this
-			}).login(email, password);
+			}).loginByCode(email, code);
 
 			if (this.request.body.tenantId) {
 				this.interstitial = '/web/assign/team?tenantId=' + this.request.body.tenantId;
 			}
-		}
-		catch (error) {
-			return this.loginError();
+
+			await this.invalidateCode();
+		} catch (error) {
+			return this.loginError(error);
 		}
 
 		// send a cookie in the response
@@ -40,11 +46,11 @@ class WebSigninRequest extends APIRequest {
 		this.finishFlow();
 	}
 
-	loginError () {
-		const error = WebErrors.invalidLogin.code;
+	loginError (sourceError) {
+		const error = WebErrors[sourceError] ? WebErrors[sourceError].code : WebErrors.loginCodeMismatch.code;
 		const email = encodeURIComponent(this.request.body.email || '');
 		const url = encodeURIComponent(this.request.body.finishUrl || '');
-		let redirect = `/web/login?error=${error}&email=${email}&url=${url}&password=true`;
+		let redirect = `/web/confirm-code?error=${error}&email=${email}&url=${url}`;
 		if (this.request.body.tenantId) {
 			redirect += '&tenantId=' + encodeURIComponent(this.request.body.tenantId || '');
 		}
@@ -71,6 +77,17 @@ class WebSigninRequest extends APIRequest {
 		return true;
 	}
 
+	async invalidateCode () {
+		const op = {
+			$unset: {
+				loginCode: true,
+				loginCodeExpiresAt: true,
+				loginCodeAttempts: true,
+			},
+		};
+		this.data.users.applyOpById(this.user.id, op);
+	}
+
 	finishFlow () {
 		if (this.interstitial) {
 			this.response.redirect(this.interstitial);
@@ -84,4 +101,4 @@ class WebSigninRequest extends APIRequest {
 	}
 }
 
-module.exports = WebSigninRequest;
+module.exports = WebSigninCodeRequest;

--- a/outbound_email/src/loginCodeHandler.js
+++ b/outbound_email/src/loginCodeHandler.js
@@ -6,8 +6,8 @@ class LoginCodeHandler extends EmailHandler {
 
 	// render the email with a login code
 	async renderEmail () {
-		this.subject = `Your sign-in code is ${code}`;
 		const code = this.user.loginCode;
+		this.subject = `Your sign-in code is ${code}`;
 		this.content = `
 <html>
 Paste the following code in your IDE to sign into CodeStream.<br/><br/>


### PR DESCRIPTION
This adds login by code to web. A couple things to note:

* The page to enter the login code looks different than in the IDE, just having one input instead of 6 separate boxes, because implementing it without React seemed like it would be pretty messy and not worth it in this case.
* This also should fix an issue with the loginCode email handler that was preventing emails from actually being sent.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/e_9VhGuDRsCxAdRr102boA?src=GitHub) by cstryker on Jan 14, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>