### PR TITLE
CDSTRM-1439: Fix org deletion with deleted user

### DIFF
--- a/api_server/modules/companies/delete_company_request.js
+++ b/api_server/modules/companies/delete_company_request.js
@@ -68,6 +68,7 @@ class DeleteCompanyRequest extends DeleteRequest {
 		const usersToDelete = teamUsers
 			.filter(user => {
 				return (
+					!user.get('deactivated') &&
 					(user.get('teamIds') || []).length === 1 &&
 					user.get('teamIds')[0] === this.everyoneTeam.id
 				);

--- a/api_server/modules/companies/test/delete_company/deactivated_user_test.js
+++ b/api_server/modules/companies/test/delete_company/deactivated_user_test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const DeleteCompanyTest = require('./delete_company_test');
+const BoundAsync = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_utils/bound_async');
+
+class DeactivatedUserTest extends DeleteCompanyTest {
+
+	get description () {
+		return 'should deactivate a company when company has a deactivated user already';
+	}
+
+	// before the test runs...
+	before (callback) {
+		BoundAsync.series(this, [
+			super.before,
+			this.deleteSecondUser
+		], callback);
+	}
+
+	deleteSecondUser (callback) {
+		this.doApiRequest(
+			{
+				method: 'delete',
+				path: `/users/${this.users[1].user.id}`,
+				requestOptions: {
+					headers: {
+						'X-Delete-User-Secret': this.apiConfig.sharedSecrets.confirmationCheat
+					}
+				},
+				token: this.token
+			},
+			callback
+		);
+	}
+}
+
+module.exports = DeactivatedUserTest;

--- a/api_server/modules/companies/test/delete_company/test.js
+++ b/api_server/modules/companies/test/delete_company/test.js
@@ -12,6 +12,7 @@ const CompanyNotFoundTest = require('./company_not_found_test');
 const UserDeletedTest = require('./user_deleted_test');
 const NonOrphanedNotDeletedTest = require('./non_orphaned_not_deleted_test');
 const TeamSubscriptionRevokedTest = require('./team_subscription_revoked_test');
+const DeactivatedUserTest = require('./deactivated_user_test');
 
 class DeleteCompanyRequestTester {
 
@@ -26,6 +27,7 @@ class DeleteCompanyRequestTester {
 		new NonOrphanedNotDeletedTest().test();
 		new AlreadyDeletedTest().test();
 		new TeamSubscriptionRevokedTest().test();
+		new DeactivatedUserTest().test();
 	}
 }
 


### PR DESCRIPTION
This ensures organization deletion still works if one of the users in the organization has already been deactivated.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/Y-RmyrJYSAqWPvGaRP69Bg?src=GitHub) by cstryker on Feb 3, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>