### PR TITLE
CDSTRM-62: Hide large team weekly email sections

### DIFF
--- a/outbound_email/src/weeklyEmailPerUserHandler.js
+++ b/outbound_email/src/weeklyEmailPerUserHandler.js
@@ -9,6 +9,8 @@ const TokenHandler = require(process.env.CSSVC_BACKEND_ROOT + '/shared/server_ut
 const ONE_HOUR = 60 * 60 * 1000;
 const ONE_DAY = 24 * ONE_HOUR;
 const ONE_WEEK = 7 * ONE_DAY;
+// suppress certain results when team size gets too big
+const SUPPRESS_TEAM_SIZE = 25;
 
 class WeeklyEmailPerUserHandler {
 
@@ -269,12 +271,16 @@ class WeeklyEmailPerUserHandler {
 				review.status === 'approved' &&
 				review.approvedAt > this.userData.contentCreatedSince
 			) {
-				this.userData.closedReviews.push(review);
+				if (this.teamData.users.length <= SUPPRESS_TEAM_SIZE) {
+					this.userData.closedReviews.push(review);
+				}
 			} else if (review.status === 'open') {
 				if ((review.reviewers || []).includes(this.user.id)) {
 					this.userData.myReviews.push(review);
 				} else if (review.createdAt > this.userData.contentCreatedSince) {
-					this.userData.newReviews.push(review);
+					if (this.teamData.users.length <= SUPPRESS_TEAM_SIZE) {
+						this.userData.newReviews.push(review);
+					}
 				}
 			}
 		});
@@ -308,12 +314,16 @@ class WeeklyEmailPerUserHandler {
 			if (codemark.post.parentPost) { return; } // codemarks under reviews don't show up as separate items
 			if (codemark.status === 'closed') {
 				if (codemark.modifiedAt > this.userData.contentCreatedSince) {
-					this.userData.closedCodemarks.push(codemark);
+					if (this.teamData.users.length <= SUPPRESS_TEAM_SIZE) {
+						this.userData.closedCodemarks.push(codemark);
+					}
 				}
 			} else if ((codemark.assignees || []).includes(this.user.id)) {
 				this.userData.myCodemarks.push(codemark);
 			} else if (codemark.createdAt > this.userData.contentCreatedSince) {
-				this.userData.newCodemarks.push(codemark);
+				if (this.teamData.users.length <= SUPPRESS_TEAM_SIZE) {
+					this.userData.newCodemarks.push(codemark);
+				}
 			}
 		});
 		this.haveContent = this.haveContent || (
@@ -347,6 +357,10 @@ class WeeklyEmailPerUserHandler {
 
 	// get any unread items for the team and user that are not covered by the other categories
 	async getMyUnreads () {
+		if (this.teamData.users.length > SUPPRESS_TEAM_SIZE) {
+			this.userData.unreads = [];
+			return;
+		}
 		this.userData.unreads = await this.getMyPosts(this.postIsUnread, 'unreads');
 		this.haveContent = this.haveContent || this.userData.unreads.length > 0;
 	}


### PR DESCRIPTION
This suppresses the "Other Unread Messages" and the "Team Activity" sections in the weekly email if an organization has more than 25 users.


[Changes reviewed on CodeStream](https://staging-api.codestream.us/r/Ya5We-trHA5di0uy/cM1qjUWGTjildsE6hj-nuw?src=GitHub) by cstryker on Feb 8, 2022

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>