### PR TITLE
NEWRELIC-5127 Unable to view Github PRs in private repos 

### DIFF
--- a/api_server/modules/github_auth/github_auth.js
+++ b/api_server/modules/github_auth/github_auth.js
@@ -12,7 +12,7 @@ const OAUTH_CONFIG = {
 	authPath: 'login/oauth/authorize',
 	tokenPath: 'login/oauth/access_token',
 	exchangeFormat: 'query',
-	scopes: 'repo,read:user,user:email,notifications',
+	scopes: 'repo,read:user,user:email,notifications,read:org',
 	noGrantType: true,
 	hasIssues: true,
 	hasCodeHosting: true,


### PR DESCRIPTION


**This PR Addresses:**  
[NEWRELIC-5127 Unable to view Github PRs in private repos ](https://issues.newrelic.com/browse/NEWRELIC-5127)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>