### PR TITLE
Add new no-auth route for MSTeams

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Node: Debugger (Remote)",
+            "port": 9230
+		}
+    ]
+}

--- a/api_server/etc/msteamsbot/template/manifest.json
+++ b/api_server/etc/msteamsbot/template/manifest.json
@@ -76,14 +76,5 @@
     "permissions": [
         "identity",
         "messageTeamMembers"
-    ],
-    "validDomains": [
-        "csaction.codestream.us",
-        "www.codestream.com",
-        "*.codestream.us",
-        "csaction.cdstrm.us",
-        "*.cdstrm.us",
-        "*.cdstrm.dev",
-        "*.*.newrelic.com"
     ]
 }

--- a/api_server/modules/msteams_auth/msteams_auth.js
+++ b/api_server/modules/msteams_auth/msteams_auth.js
@@ -7,7 +7,7 @@ const OAuthModule = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/oa
 const OAUTH_CONFIG = {
 	provider: 'msteams',
 	host: 'msteams',
-	hasSharing: true
+	hasSharing: true,
 	needsConfigure: true
 };
 

--- a/api_server/modules/msteams_auth/msteams_auth.js
+++ b/api_server/modules/msteams_auth/msteams_auth.js
@@ -8,6 +8,7 @@ const OAUTH_CONFIG = {
 	provider: 'msteams',
 	host: 'msteams',
 	hasSharing: true
+	needsConfigure: true
 };
 
 const ROUTES = [];

--- a/api_server/modules/providers/msteams_conversation_bot.js
+++ b/api_server/modules/providers/msteams_conversation_bot.js
@@ -81,9 +81,9 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 					teamMembers = await TeamsInfo.getTeamMembers(context);
 				}
 
-				// if this looks like a guid without hypens (aka a signup token...)
+				// if the action is signin, then we assume signInCode was also supplied
 				if (action === 'signin') {
-                    const token = context.activity.value?.signInCode?.trim();
+					const token = context.activity.value?.signInCode?.trim();
 					const result = await context.turnState.get('cs_databaseAdapter').complete({
 						tenantId: channelData.tenant.id,
 						token: token

--- a/api_server/modules/providers/msteams_conversation_bot.js
+++ b/api_server/modules/providers/msteams_conversation_bot.js
@@ -12,21 +12,22 @@ const {
 	CardFactory,
 	TeamsInfo,
 	TeamsActivityHandler,
-	TurnContext
+	TurnContext,
 } = require('botbuilder');
 
 const PERSONAL_BOT_MESSAGE = 'Please run this command from your personal bot chat.';
 const TEAM_BOT_MESSAGE = 'Please run this command from a team channel.';
 // const HELP_URL = 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/';
-// Keys of properties used to store 
+// Keys of properties used to store
 const STATE_PROPERTY_WELCOMED_USER = 'welcomedUser';
 const STATE_PROPERTY_CODESTREAM_USER_ID = 'codestreamUserId';
 
-const OPEN_EXTERNAL_LINK_ICON = 'https://images.codestream.com/misc/link-external_transparent-32x32.png';
+const OPEN_EXTERNAL_LINK_ICON =
+	'https://images.codestream.com/misc/link-external_transparent-32x32.png';
 
 class MSTeamsConversationBot extends TeamsActivityHandler {
 	// note this is a singleton, and no instance members should be used
-	constructor () {
+	constructor() {
 		super();
 
 		this.onInstallationUpdateAdd(async (context, next) => {
@@ -38,16 +39,15 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 
 		this.onMessage(async (context, next) => {
 			try {
-				// this needs to be run before we access the text as it 
-				// removes the <at>CodeStream</at> part of 
+				// this needs to be run before we access the text as it
+				// removes the <at>CodeStream</at> part of
 				TurnContext.removeRecipientMention(context.activity);
 
-                const action = context.activity.value?.action?.trim();
-                const command = context.activity.text?.trim() 
-                    ?? context.activity.value?.command?.trim();
+				const action = context.activity.value?.action?.trim();
+				const command = context.activity.text?.trim() ?? context.activity.value?.command?.trim();
 
 				// store this for possible error logging later
-				context.turnState.set('cs_bot_text', JSON.stringify({ action, command }));
+				await context.turnState.set('cs_bot_text', JSON.stringify({ action, command }));
 				const didBotWelcomeUser = await this.getState(context, STATE_PROPERTY_WELCOMED_USER, false);
 
 				let teamDetails;
@@ -55,12 +55,12 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 				let teamMembers;
 				const channelData = context.activity.channelData;
 				const team = channelData && channelData.team ? channelData.team : undefined;
-				const teamId = team && typeof (team.id) === 'string' ? team.id : undefined;
+				const teamId = team && typeof team.id === 'string' ? team.id : undefined;
 				const isPersonalChat = teamId === undefined;
 
 				// not checking type since this can return undefined
 				if (!didBotWelcomeUser && isPersonalChat) {
-					// if we haven't welcomed this user AND their first command isn't signin, 
+					// if we haven't welcomed this user AND their first command isn't signin,
 					// AND they're in a personal chat
 					// give them some additional info
 					if (command !== 'signin') {
@@ -86,17 +86,23 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 					const token = context.activity.value?.signInCode?.trim();
 					const result = await context.turnState.get('cs_databaseAdapter').complete({
 						tenantId: channelData.tenant.id,
-						token: token
+						token: token,
 					});
 					if (result && result.success) {
-						await this.setState(context, STATE_PROPERTY_CODESTREAM_USER_ID, result.codeStreamUserId);
-						await context.sendActivity('Next step, go to any channel where you\'d like to use CodeStream, type `@`, select `Get bots` and then select the CodeStream bot. Once you\'ve added the bot, mention it with the `connect` command.');
+						await this.setState(
+							context,
+							STATE_PROPERTY_CODESTREAM_USER_ID,
+							result.codeStreamUserId
+						);
+						await context.sendActivity(
+							"Next step, go to any channel where you'd like to use CodeStream, type `@`, select `Get bots` and then select the CodeStream bot. Once you've added the bot, mention it with the `connect` command."
+						);
+					} else {
+						await context.sendActivity(
+							'Oops, we hit a snag trying to connect to CodeStream. Please try signing in again!'
+						);
 					}
-					else {
-						await context.sendActivity('Oops, we hit a snag trying to connect to CodeStream. Please try signing in again!');
-					}
-				}
-				else {
+				} else {
 					switch (command?.toLocaleLowerCase()) {
 						// start secret commands
 						case 'install':
@@ -111,8 +117,7 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 						case 'status':
 							if (teamId) {
 								await this.status(context);
-							}
-							else {
+							} else {
 								await this.statusPersonal(context);
 							}
 							break;
@@ -122,26 +127,30 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 						case 'disconnectall':
 						case 'disconnect-all':
 							if (teamId) {
-								await this.disconnectAll(context, context.activity, teamDetails, teamChannels, channelData.tenant.id);
+								await this.disconnectAll(
+									context,
+									context.activity,
+									teamDetails,
+									teamChannels,
+									channelData.tenant.id
+								);
 							}
 							break;
-							// end secret commands
+						// end secret commands
 
 						// start personal commands
 						case 'login':
 						case 'signin':
 							if (teamId) {
 								await context.sendActivity(PERSONAL_BOT_MESSAGE);
-							}
-							else {
+							} else {
 								await this.signin(context);
 							}
 							break;
 						case 'signup':
 							if (teamId) {
 								await context.sendActivity(PERSONAL_BOT_MESSAGE);
-							}
-							else {
+							} else {
 								await this.signup(context);
 							}
 							break;
@@ -149,33 +158,43 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 						case 'signout':
 							if (teamId) {
 								await context.sendActivity(PERSONAL_BOT_MESSAGE);
-							}
-							else {
+							} else {
 								await this.signout(context);
 							}
 							break;
-							// end personal commands
+						// end personal commands
 
 						// start commands that work in public chats/teams
 						case 'connect':
 							if (teamId) {
-								await this.connect(context, context.activity, teamDetails, teamChannels, teamMembers, channelData.tenant.id);
-							}
-							else {
+								await this.connect(
+									context,
+									context.activity,
+									teamDetails,
+									teamChannels,
+									teamMembers,
+									channelData.tenant.id
+								);
+							} else {
 								await context.sendActivity(TEAM_BOT_MESSAGE);
 							}
 							break;
 						case 'disconnect':
 							if (teamId) {
-								await this.disconnect(context, context.activity, teamDetails, teamChannels, channelData.tenant.id);
-							}
-							else {
+								await this.disconnect(
+									context,
+									context.activity,
+									teamDetails,
+									teamChannels,
+									channelData.tenant.id
+								);
+							} else {
 								await context.sendActivity(TEAM_BOT_MESSAGE);
 							}
 							break;
-							// end commands that work in public chats/teams
+						// end commands that work in public chats/teams
 
-						// start commands that work everywhere			
+						// start commands that work everywhere
 						case 'welcome':
 						case 'start':
 						case 'init':
@@ -186,19 +205,19 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 						case 'help':
 							if (teamId) {
 								await this.help(context);
-							}
-							else {
+							} else {
 								await this.helpPersonal(context);
 							}
 							break;
 						default:
-							await context.sendActivity(`Sorry, I didn't understand '${command}', but thanks for checking out CodeStream. Type 'help' if you need assistance.`);
+							await context.sendActivity(
+								`Sorry, I didn't understand '${command}', but thanks for checking out CodeStream. Type 'help' if you need assistance.`
+							);
 							break;
-							// end commands that work everywhere
+						// end commands that work everywhere
 					}
 				}
-			}
-			finally {
+			} finally {
 				// we don't need a catch here since the global
 				// error handler in MSTeamsBotFrameworkAdapter will capture it
 
@@ -210,19 +229,18 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 	}
 
 	// assign any request-specific data on the first instance
-	initialize (options) {
+	initialize(options) {
 		Object.assign(this, options);
 	}
 
-
 	/**
-	 * Fetch properties from the user state 
-	 * 
+	 * Fetch properties from the user state
+	 *
 	 * @param  {object} context the MST context object
 	 * @param  {string} key the key of the data
 	 * @param  {object} defaultValue if supplied, will return this value instead of undefined
 	 */
-	async getState (context, key, defaultValue) {
+	async getState(context, key, defaultValue) {
 		const userState = await context.turnState.get('cs_stateAdapter');
 		if (!userState) return undefined;
 
@@ -233,13 +251,13 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 	}
 
 	/**
-	 * Set properties into the user state 
-	 * 
+	 * Set properties into the user state
+	 *
 	 * @param  {object} context the MST context object
 	 * @param  {string} key the key of the data
 	 * @param  {object} value the value of this key
 	 */
-	async setState (context, key, value) {
+	async setState(context, key, value) {
 		const userState = await context.turnState.get('cs_stateAdapter');
 		if (!userState) return false;
 
@@ -252,10 +270,10 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 
 	/**
 	 * Deletes all keys for this user
-	 * 
+	 *
 	 * @param  {object} context the MST context object
 	 */
-	async deleteState (context) {
+	async deleteState(context) {
 		const userState = await context.turnState.get('cs_stateAdapter');
 		if (!userState) return false;
 
@@ -265,10 +283,10 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 
 	/**
 	 * Save the state of this user. This should usually be run once per request (at the end)
-	 * 
+	 *
 	 * @param  {object} context the MST context object
 	 */
-	async saveState (context) {
+	async saveState(context) {
 		const userState = await context.turnState.get('cs_stateAdapter');
 		if (!userState) return;
 
@@ -276,10 +294,14 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 	}
 
 	// connects the channel to CodeStream
-	async connect (context, activity, teamDetails, teamChannels, teamMembers, tenantId) {
+	async connect(context, activity, teamDetails, teamChannels, teamMembers, tenantId) {
 		const codeStreamUserId = await this.getState(context, STATE_PROPERTY_CODESTREAM_USER_ID);
 		if (!codeStreamUserId) {
-			await context.sendActivity(MessageFactory.text('Please run the `signin` command from the personal CodeStream bot chat before connecting.'));
+			await context.sendActivity(
+				MessageFactory.text(
+					'Please run the `signin` command from the personal CodeStream bot chat before connecting.'
+				)
+			);
 		} else {
 			const conversationReference = TurnContext.getConversationReference(activity);
 			const result = await context.turnState.get('cs_databaseAdapter').connect({
@@ -288,559 +310,613 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 				tenantId: tenantId,
 				teamChannels: teamChannels,
 				teamMembers: teamMembers,
-				codeStreamUserId: codeStreamUserId
+				codeStreamUserId: codeStreamUserId,
 			});
 			if (result) {
 				if (result.success) {
-					await context.sendActivity('This channel is now ready to receive messages from CodeStream.');
-				}
-				else {
+					await context.sendActivity(
+						'This channel is now ready to receive messages from CodeStream.'
+					);
+				} else {
 					if (result.reason === 'signin') {
-						await context.sendActivity(MessageFactory.text('Please run the `signin` command from the personal CodeStream bot chat before connecting.'));
-					}
-					else {
-						await context.sendActivity(MessageFactory.text('Oops, we had a problem connecting CodeStream to this conversation. Please try again.'));
+						await context.sendActivity(
+							MessageFactory.text(
+								'Please run the `signin` command from the personal CodeStream bot chat before connecting.'
+							)
+						);
+					} else {
+						await context.sendActivity(
+							MessageFactory.text(
+								'Oops, we had a problem connecting CodeStream to this conversation. Please try again.'
+							)
+						);
 					}
 				}
-			}
-			else {
-				await context.sendActivity(MessageFactory.text('Oops, we had a problem connecting CodeStream to this conversation. Please try again.'));
+			} else {
+				await context.sendActivity(
+					MessageFactory.text(
+						'Oops, we had a problem connecting CodeStream to this conversation. Please try again.'
+					)
+				);
 			}
 		}
 	}
 
 	// disconnects the channel from CodeStream
-	async disconnect (context, activity, teamDetails, teamChannels, tenantId) {
+	async disconnect(context, activity, teamDetails, teamChannels, tenantId) {
 		const codeStreamUserId = await this.getState(context, STATE_PROPERTY_CODESTREAM_USER_ID);
 		if (!codeStreamUserId) {
-			await context.sendActivity(MessageFactory.text('Please run the `signin` command from the personal CodeStream bot chat before disconnecting.'));
+			await context.sendActivity(
+				MessageFactory.text(
+					'Please run the `signin` command from the personal CodeStream bot chat before disconnecting.'
+				)
+			);
 		} else {
 			const conversationReference = TurnContext.getConversationReference(activity);
 			const result = await context.turnState.get('cs_databaseAdapter').disconnect({
 				conversation: conversationReference,
 				team: teamDetails,
 				tenantId: tenantId,
-				teamChannels: teamChannels
+				teamChannels: teamChannels,
 			});
 
 			if (result && result.success) {
-				await context.sendActivity(MessageFactory.text('CodeStream has been disconnected from this channel.'));
-			}
-			else {
-				await context.sendActivity(MessageFactory.text('Oops, we had a problem disconnecting CodeStream from this conversation. Please try again.'));
+				await context.sendActivity(
+					MessageFactory.text('CodeStream has been disconnected from this channel.')
+				);
+			} else {
+				await context.sendActivity(
+					MessageFactory.text(
+						'Oops, we had a problem disconnecting CodeStream from this conversation. Please try again.'
+					)
+				);
 			}
 		}
 	}
 
 	// secret command: disconnects all the teams, aka removes them from msteams_team collection
-	async disconnectAll (context, activity, teamDetails, teamChannels, tenantId) {
+	async disconnectAll(context, activity, teamDetails, teamChannels, tenantId) {
 		const codeStreamUserId = await this.getState(context, STATE_PROPERTY_CODESTREAM_USER_ID);
 		if (!codeStreamUserId) {
-			await context.sendActivity(MessageFactory.text('Please run the `signin` command from the personal CodeStream bot chat before disconnecting all.'));
+			await context.sendActivity(
+				MessageFactory.text(
+					'Please run the `signin` command from the personal CodeStream bot chat before disconnecting all.'
+				)
+			);
 		} else {
 			const result = await context.turnState.get('cs_databaseAdapter').disconnectAll({
 				teamId: teamDetails.id,
-				tenantId: tenantId
+				tenantId: tenantId,
 			});
 
 			if (result && result.success) {
-				await context.sendActivity(MessageFactory.text('CodeStream has been disconnected from all conversations.'));
-			}
-			else {
-				await context.sendActivity(MessageFactory.text('Oops, we had a problem disconnecting CodeStream from all conversations. Please try again.'));
+				await context.sendActivity(
+					MessageFactory.text('CodeStream has been disconnected from all conversations.')
+				);
+			} else {
+				await context.sendActivity(
+					MessageFactory.text(
+						'Oops, we had a problem disconnecting CodeStream from all conversations. Please try again.'
+					)
+				);
 			}
 		}
 	}
 
 	// signs the current user out of CodeStream (assuming they have signed in before)
-	async signout (context) {
+	async signout(context) {
 		const codeStreamUserId = await this.getState(context, STATE_PROPERTY_CODESTREAM_USER_ID);
 		if (!codeStreamUserId) {
-			await context.sendActivity(MessageFactory.text('Please run the `signin` command from the personal CodeStream bot chat before signing out.'));
+			await context.sendActivity(
+				MessageFactory.text(
+					'Please run the `signin` command from the personal CodeStream bot chat before signing out.'
+				)
+			);
 		} else {
 			const result = await context.turnState.get('cs_databaseAdapter').signout({
 				tenantId: context.activity.channelData.tenant.id,
-				codeStreamUserId: codeStreamUserId
+				codeStreamUserId: codeStreamUserId,
 			});
 			if (result && result.success) {
 				await context.sendActivity(MessageFactory.text('You have been signed out of CodeStream.'));
 				await this.deleteState(context);
-			}
-			else {
-				await context.sendActivity(MessageFactory.text('Oops, we had a problem signing you out of CodeStream. Please try again.'));
+			} else {
+				await context.sendActivity(
+					MessageFactory.text(
+						'Oops, we had a problem signing you out of CodeStream. Please try again.'
+					)
+				);
 			}
 		}
 	}
 
 	// secret command: you're awesome!
-	async easterEgg (context) {
-		await context.sendActivity(MessageFactory.text('You\'re awesome!'));
+	async easterEgg(context) {
+		await context.sendActivity(MessageFactory.text("You're awesome!"));
 	}
 
 	// sends out some debugging info
-	async debug (context) {
+	async debug(context) {
 		const codeStreamUserId = await this.getState(context, STATE_PROPERTY_CODESTREAM_USER_ID);
 		const tenantId = context.activity.channelData.tenant.id;
 		const serverDebug = await context.turnState.get('cs_databaseAdapter').debug({
-			tenantId: tenantId
+			tenantId: tenantId,
 		});
 		const debug = {
 			api: this.publicApiUrl,
 			tenantId: tenantId,
-			codeStreamUserId: codeStreamUserId
+			codeStreamUserId: codeStreamUserId,
 		};
-		await context.sendActivity(MessageFactory.text(JSON.stringify({ ...serverDebug, ...debug }, null, 4)));
+		await context.sendActivity(
+			MessageFactory.text(JSON.stringify({ ...serverDebug, ...debug }, null, 4))
+		);
 	}
 
-	async status (context) {
+	async status(context) {
 		const tenantId = context.activity.channelData.tenant.id;
 		const results = await context.turnState.get('cs_databaseAdapter').status({
-			tenantId: tenantId
+			tenantId: tenantId,
 		});
 		if (results && results.teams) {
-			const facts = results.teams.map(_ => {
+			const facts = results.teams.map((_) => {
 				return {
 					title: _.get('name'),
-					value: 'connected'
+					value: 'connected',
 				};
 			});
 
 			let body = [];
 
-			body.push({
-				type: 'TextBlock',
-				size: 'Medium',
-				weight: 'Bolder',
-				text: 'CodeStream Teams'
-			},
-			{
-				type: 'ColumnSet',
-				columns: [
-					{
-						type: 'Column',
-						items: [
-							{
-								type: 'FactSet',
-								facts: facts
-							}
-						],
-						width: 'stretch'
-					}
-				]
-			});
+			body.push(
+				{
+					type: 'TextBlock',
+					size: 'Medium',
+					weight: 'Bolder',
+					text: 'CodeStream Teams',
+				},
+				{
+					type: 'ColumnSet',
+					columns: [
+						{
+							type: 'Column',
+							items: [
+								{
+									type: 'FactSet',
+									facts: facts,
+								},
+							],
+							width: 'stretch',
+						},
+					],
+				}
+			);
 
 			await this.sendAdaptiveCard(context, body);
-		}
-		else {
+		} else {
 			await context.sendActivity(MessageFactory.text('Status Unknown'));
 		}
 	}
 
-	async statusPersonal (context) {
+	async statusPersonal(context) {
 		const codeStreamUserId = await this.getState(context, STATE_PROPERTY_CODESTREAM_USER_ID);
 		const tenantId = context.activity.channelData.tenant.id;
 		const results = await context.turnState.get('cs_databaseAdapter').status({
-			tenantId: tenantId
+			tenantId: tenantId,
 		});
 		if (results && results.teams) {
-			const facts = results.teams.map(_ => {
+			const facts = results.teams.map((_) => {
 				return {
 					title: _.get('name'),
-					value: 'connected'
+					value: 'connected',
 				};
 			});
 
 			let body = [];
-			
-			body.push({
-				type: 'TextBlock',
-				size: 'Medium',
-				weight: 'Bolder',
-				text: 'CodeStream Teams'
-			},
-			{
-				type: 'ColumnSet',
-				columns: [
-					{
-						type: 'Column',
-						items: [
-							{
-								type: 'FactSet',
-								facts: facts
-							}
-						],
-						width: 'stretch'
-					}
-				]
-			},
-			{
-				type: 'TextBlock',
-				size: 'Medium',
-				weight: 'Bolder',
-				text: `Your CodeStream userId: ${codeStreamUserId}`
-			});
 
+			body.push(
+				{
+					type: 'TextBlock',
+					size: 'Medium',
+					weight: 'Bolder',
+					text: 'CodeStream Teams',
+				},
+				{
+					type: 'ColumnSet',
+					columns: [
+						{
+							type: 'Column',
+							items: [
+								{
+									type: 'FactSet',
+									facts: facts,
+								},
+							],
+							width: 'stretch',
+						},
+					],
+				},
+				{
+					type: 'TextBlock',
+					size: 'Medium',
+					weight: 'Bolder',
+					text: `Your CodeStream userId: ${codeStreamUserId}`,
+				}
+			);
 
 			await this.sendAdaptiveCard(context, body);
-		}
-		else {
+		} else {
 			await context.sendActivity(MessageFactory.text('Status Unknown'));
 		}
 	}
 
 	// uninstalls the app from the CS team based on the tenantId
 	// will only work if there is 1 CS team attached
-	async uninstall (context) {
+	async uninstall(context) {
 		const codeStreamUserId = await this.getState(context, STATE_PROPERTY_CODESTREAM_USER_ID);
 		if (!codeStreamUserId) {
-			await context.sendActivity(MessageFactory.text('Please run the `signin` command from the personal CodeStream bot chat before uninstalling.'));
+			await context.sendActivity(
+				MessageFactory.text(
+					'Please run the `signin` command from the personal CodeStream bot chat before uninstalling.'
+				)
+			);
 		} else {
 			const result = await context.turnState.get('cs_databaseAdapter').uninstall({
-				tenantId: context.activity.channelData.tenant.id
+				tenantId: context.activity.channelData.tenant.id,
 			});
 
-			await context.sendActivity(MessageFactory.text(`Uninstall ${result ? 'succeeded' : 'failed'}`));
+			await context.sendActivity(
+				MessageFactory.text(`Uninstall ${result ? 'succeeded' : 'failed'}`)
+			);
 		}
 	}
 
 	// returns a way for a user to signin if their team is not connected
-	async signin (context) {
+	async signin(context) {
 		let body = [];
 
 		body.push(
-            {
-                type: "Input.Text",
-                label: "Paste your sign-in code from CodeStream. If you don't have one, go to CodeStream, click on your username at the top, select Integrations, and then click on the Microsoft Teams button.",
-                placeholder: "Your sign-in code",
-                id: "signInCode"
-            },
-            {
-                type: 'ActionSet',
-                actions: [
-                    {
-                        type: "Action.Submit",
-                        title: "Sign-in",
-                        id: "submitSignInCode",
-                        data: {
-                            action: "signin"
-                        }
-                    }
-                ]
-            }
-        );
+			{
+				type: 'Input.Text',
+				label:
+					"Paste your sign-in code from CodeStream. If you don't have one, go to CodeStream, click on your username at the top, select Integrations, and then click on the Microsoft Teams button.",
+				placeholder: 'Your sign-in code',
+				id: 'signInCode',
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.Submit',
+						title: 'Sign-in',
+						id: 'submitSignInCode',
+						data: {
+							action: 'signin',
+						},
+					},
+				],
+			}
+		);
 
 		await this.sendAdaptiveCard(context, body);
 	}
 
 	// provides a way for a user to signup
-	async signup (context) {
+	async signup(context) {
 		let body = [];
 
-		body.push({
-			type: 'TextBlock',
-			text: `Download the CodeStream IDE extension to get started!`,
-			wrap: true,
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-				{
-					type: 'Action.OpenUrl',
-					title: 'Sign up',
-					url: 'https://www.codestream.com',
-					iconUrl: OPEN_EXTERNAL_LINK_ICON
-				}
-			]
-		});
+		body.push(
+			{
+				type: 'TextBlock',
+				text: `Download the CodeStream IDE extension to get started!`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.OpenUrl',
+						title: 'Sign up',
+						url: 'https://www.codestream.com',
+						iconUrl: OPEN_EXTERNAL_LINK_ICON,
+					},
+				],
+			}
+		);
 
 		await this.sendAdaptiveCard(context, body);
 	}
 
-	async botInstalledPersonal (context) {
+	async botInstalledPersonal(context) {
 		let body = [];
 
-		body.push({
-			type: 'TextBlock',
-			size: 'Medium',
-			text: 'Welcome to New Relic CodeStream for Microsoft Teams!',
-			wrap: true,
-			color: 'good',
-			weight: 'bolder',
-			size: 'large',
-			horizontalAlignment: 'center',
-		},
-		{
-			type: 'TextBlock',
-			text: `The CodeStream bot allows you to share discussions from CodeStream to any channel on Teams. If you already have a CodeStream account, click the **Sign In** button to get started.`,
-			wrap: true,
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-				{
-					type: 'Action.Submit',
-					title: 'Sign In',
-                    data: {
-                        command: "signin",
-                        msteams: {
-                            type: "messageBack",
-                        }
-                    }
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `Click the **Detailed Instructions** button to get more detailed information about our Teams integration including a full list of available commands. If you need a CodeStream account, click **Download CodeStream** button to get started!`,
-			wrap: true,
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-				{
-					type: 'Action.OpenUrl',
-					title: 'Detailed Instructions',
-					url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
-					iconUrl: OPEN_EXTERNAL_LINK_ICON
-				},
-				{
-					type: 'Action.OpenUrl',
-					title: 'Download CodeStream',
-					url: 'https://www.codestream.com',
-					iconUrl: OPEN_EXTERNAL_LINK_ICON
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `You can always type **help** to get full list of available commands`,
-			wrap: true
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-				{
-					type: 'Action.ShowCard',
-					title: 'Help',
-					card: {
-						type: 'AdaptiveCard',
-						body: [
-							{
-								type: "TextBlock",
-								text: "Here's a list of personal commands I can process:\r",
-								wrap: true
+		body.push(
+			{
+				type: 'TextBlock',
+				size: 'Medium',
+				text: 'Welcome to New Relic CodeStream for Microsoft Teams!',
+				wrap: true,
+				color: 'good',
+				weight: 'bolder',
+				size: 'large',
+				horizontalAlignment: 'center',
+			},
+			{
+				type: 'TextBlock',
+				text: `The CodeStream bot allows you to share discussions from CodeStream to any channel on Teams. If you already have a CodeStream account, click the **Sign In** button to get started.`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.Submit',
+						title: 'Sign In',
+						data: {
+							command: 'signin',
+							msteams: {
+								type: 'messageBack',
 							},
-							{
-								type: "TextBlock",
-								text: "- **help** - view list of available commands\r- **signin** - sign in to CodeStream\r- **signup** - sign up for CodeStream\r- **signout** - sign out of CodeStream\r\r",
-								wrap: true
-							},
-							{
-								type: "TextBlock",
-								text: "Here's a list of channel commands I can process:\r",
-								wrap: true
-							},
-							{
-								type: "TextBlock",
-								text: "- **connect** - connect a Teams channel to CodeStream\r- **disconnect** - disconnect a Teams channel from CodeStream",
-								wrap: true
-							}
-						]
-					}
-				}
-			]
-		});
-
-		await this.sendAdaptiveCard(context, body);
-	}
-
-	async help (context) {
-		let body = [];
-
-		body.push({
-			type: 'TextBlock',
-			size: 'Medium',
-			text: 'The CodeStream bot allows you to share discussions from CodeStream to any channel on Teams. You can use any of the following commands:',
-			wrap: true
-		},
-		{
-			type: 'ColumnSet',
-			columns: [
-				{
-					type: 'Column',
-					items: [
-						{
-							type: 'FactSet',
-							facts: [
+						},
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `Click the **Detailed Instructions** button to get more detailed information about our Teams integration including a full list of available commands. If you need a CodeStream account, click **Download CodeStream** button to get started!`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.OpenUrl',
+						title: 'Detailed Instructions',
+						url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
+						iconUrl: OPEN_EXTERNAL_LINK_ICON,
+					},
+					{
+						type: 'Action.OpenUrl',
+						title: 'Download CodeStream',
+						url: 'https://www.codestream.com',
+						iconUrl: OPEN_EXTERNAL_LINK_ICON,
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `You can always type **help** to get full list of available commands`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.ShowCard',
+						title: 'Help',
+						card: {
+							type: 'AdaptiveCard',
+							body: [
 								{
-									title: 'connect',
-									value: 'Connect this channel to CodeStream.'
+									type: 'TextBlock',
+									text: "Here's a list of personal commands I can process:\r",
+									wrap: true,
 								},
 								{
-									title: 'disconnect',
-									value: 'Disconnect this channel from CodeStream.'
-								}
-							]
-						}
-					],
-					width: 'stretch'
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `If you already have a CodeStream account, click the **Sign In** button to get started.`,
-			wrap: true,
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-                {
-					type: 'Action.Submit',
-					title: 'Sign In',
-                    data: {
-                        command: "signin",
-                        msteams: {
-                            type: "messageBack",
-                        }
-                    }
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `Click the **Detailed Instructions** button to get more detailed information about our Teams integration including a full list of available commands. If you need a CodeStream account, click **Download CodeStream** button to get started!`,
-			wrap: true,
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-				{
-					type: 'Action.OpenUrl',
-					title: 'Detailed Instructions',
-					url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
-					iconUrl: OPEN_EXTERNAL_LINK_ICON
-				},
-				{
-					type: 'Action.OpenUrl',
-					title: 'Download CodeStream',
-					url: 'https://www.codestream.com',
-					iconUrl: OPEN_EXTERNAL_LINK_ICON
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `You can always type **help** to get full list of available commands`,
-			wrap: true
-		});
+									type: 'TextBlock',
+									text: '- **help** - view list of available commands\r- **signin** - sign in to CodeStream\r- **signup** - sign up for CodeStream\r- **signout** - sign out of CodeStream\r\r',
+									wrap: true,
+								},
+								{
+									type: 'TextBlock',
+									text: "Here's a list of channel commands I can process:\r",
+									wrap: true,
+								},
+								{
+									type: 'TextBlock',
+									text: '- **connect** - connect a Teams channel to CodeStream\r- **disconnect** - disconnect a Teams channel from CodeStream',
+									wrap: true,
+								},
+							],
+						},
+					},
+				],
+			}
+		);
 
 		await this.sendAdaptiveCard(context, body);
 	}
 
-	async helpPersonal (context, userName) {
+	async help(context) {
 		let body = [];
-		
+
+		body.push(
+			{
+				type: 'TextBlock',
+				size: 'Medium',
+				text: 'The CodeStream bot allows you to share discussions from CodeStream to any channel on Teams. You can use any of the following commands:',
+				wrap: true,
+			},
+			{
+				type: 'ColumnSet',
+				columns: [
+					{
+						type: 'Column',
+						items: [
+							{
+								type: 'FactSet',
+								facts: [
+									{
+										title: 'connect',
+										value: 'Connect this channel to CodeStream.',
+									},
+									{
+										title: 'disconnect',
+										value: 'Disconnect this channel from CodeStream.',
+									},
+								],
+							},
+						],
+						width: 'stretch',
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `If you already have a CodeStream account, click the **Sign In** button to get started.`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.Submit',
+						title: 'Sign In',
+						data: {
+							command: 'signin',
+							msteams: {
+								type: 'messageBack',
+							},
+						},
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `Click the **Detailed Instructions** button to get more detailed information about our Teams integration including a full list of available commands. If you need a CodeStream account, click **Download CodeStream** button to get started!`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.OpenUrl',
+						title: 'Detailed Instructions',
+						url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
+						iconUrl: OPEN_EXTERNAL_LINK_ICON,
+					},
+					{
+						type: 'Action.OpenUrl',
+						title: 'Download CodeStream',
+						url: 'https://www.codestream.com',
+						iconUrl: OPEN_EXTERNAL_LINK_ICON,
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `You can always type **help** to get full list of available commands`,
+				wrap: true,
+			}
+		);
+
+		await this.sendAdaptiveCard(context, body);
+	}
+
+	async helpPersonal(context, userName) {
+		let body = [];
+
 		if (userName) {
 			body.push({
 				type: 'TextBlock',
 				size: 'Medium',
 				text: `Hey ${userName}, welcome to CodeStream!`,
-				wrap: true
+				wrap: true,
 			});
 		}
 
-		body.push({
-			type: 'TextBlock',
-			size: 'Medium',
-			text: 'The CodeStream bot allows you to share discussions from CodeStream to any channel on Teams. You can use any of the following commands:',
-			wrap: true
-		},
-		{
-			type: 'ColumnSet',
-			columns: [
-				{
-					type: 'Column',
-					items: [
-						{
-							type: 'FactSet',
-							facts: [
-								{
-									title: 'signin',
-									value: 'Sign in to start using CodeStream.'
-								},
-								{
-									title: 'signout',
-									value: 'Sign out of CodeStream.'
-								}
-							]
-						}
-					],
-					width: 'stretch'
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `If you already have a CodeStream account, click the **Sign In** button to get started.`,
-			wrap: true,
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-                {
-					type: 'Action.Submit',
-					title: 'Sign In',
-                    data: {
-                        command: "signin",
-                        msteams: {
-                            type: "messageBack",
-                        }
-                    }
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `Click the **Detailed Instructions** button to get more detailed information about our Teams integration including a full list of available commands. If you need a CodeStream account, click **Download CodeStream** button to get started!`,
-			wrap: true,
-		},
-		{
-			type: 'ActionSet',
-			actions: [
-				{
-					type: 'Action.OpenUrl',
-					title: 'Detailed Instructions',
-					url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
-					iconUrl: OPEN_EXTERNAL_LINK_ICON
-				},
-				{
-					type: 'Action.OpenUrl',
-					title: 'Download CodeStream',
-					url: 'https://www.codestream.com',
-					iconUrl: OPEN_EXTERNAL_LINK_ICON
-				}
-			]
-		},
-		{
-			type: 'TextBlock',
-			text: `You can always type **help** to get full list of available commands`,
-			wrap: true
-		});
+		body.push(
+			{
+				type: 'TextBlock',
+				size: 'Medium',
+				text: 'The CodeStream bot allows you to share discussions from CodeStream to any channel on Teams. You can use any of the following commands:',
+				wrap: true,
+			},
+			{
+				type: 'ColumnSet',
+				columns: [
+					{
+						type: 'Column',
+						items: [
+							{
+								type: 'FactSet',
+								facts: [
+									{
+										title: 'signin',
+										value: 'Sign in to start using CodeStream.',
+									},
+									{
+										title: 'signout',
+										value: 'Sign out of CodeStream.',
+									},
+								],
+							},
+						],
+						width: 'stretch',
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `If you already have a CodeStream account, click the **Sign In** button to get started.`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.Submit',
+						title: 'Sign In',
+						data: {
+							command: 'signin',
+							msteams: {
+								type: 'messageBack',
+							},
+						},
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `Click the **Detailed Instructions** button to get more detailed information about our Teams integration including a full list of available commands. If you need a CodeStream account, click **Download CodeStream** button to get started!`,
+				wrap: true,
+			},
+			{
+				type: 'ActionSet',
+				actions: [
+					{
+						type: 'Action.OpenUrl',
+						title: 'Detailed Instructions',
+						url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
+						iconUrl: OPEN_EXTERNAL_LINK_ICON,
+					},
+					{
+						type: 'Action.OpenUrl',
+						title: 'Download CodeStream',
+						url: 'https://www.codestream.com',
+						iconUrl: OPEN_EXTERNAL_LINK_ICON,
+					},
+				],
+			},
+			{
+				type: 'TextBlock',
+				text: `You can always type **help** to get full list of available commands`,
+				wrap: true,
+			}
+		);
 
 		await this.sendAdaptiveCard(context, body);
 	}
 
-	async sendAdaptiveCard(context, body){
+	async sendAdaptiveCard(context, body) {
 		const payload = {
 			type: 'AdaptiveCard',
 			body: body,
-			'$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
-			version: '1.4'
+			$schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+			version: '1.4',
 		};
 
 		await context.sendActivity({
-			attachments: [CardFactory.adaptiveCard(payload)]
+			attachments: [CardFactory.adaptiveCard(payload)],
 		});
 	}
 }

--- a/api_server/modules/providers/msteams_database_adapter.js
+++ b/api_server/modules/providers/msteams_database_adapter.js
@@ -155,21 +155,13 @@ class MSTeamsDatabaseAdapter {
 			signupTokenService.initialize();
 
 			const signupToken = await signupTokenService.find(data.token);
-			if (!signupToken || signupToken.token !== data.token || signupToken.target !== 'msteams') {
+			if (!signupToken || signupToken.token !== data.token) {
 				this.api.log('Invalid signup token');
 				return {
 					reason: 'generic',
 					success: false
 				};
 			}
-
-			// sync the old token with the new data 
-			// (this will cause any tokens with the same token to be deleted)
-			signupToken.tenantId = data.tenantId;
-			signupTokenService.insert(signupToken.token, signupToken.userId, {
-				expiresAt: signupToken.expiresAt,
-				teamIds: signupToken.teamIds
-			});
 
 			// allow all the teams that this user is part of to use MST
 			// these are stored on the signup token when issued

--- a/api_server/modules/providers/provider_test_constants.js
+++ b/api_server/modules/providers/provider_test_constants.js
@@ -175,6 +175,7 @@ const STANDARD_PROVIDER_HOSTS = {
 		host: 'msteams',
 		name: 'msteams',
 		isEnterprise: false,
+		needsConfigure: true,
 		hasSharing: true
 	},
 	'okta*com': {

--- a/api_server/modules/users/generate_msteams_connect_code.js
+++ b/api_server/modules/users/generate_msteams_connect_code.js
@@ -26,12 +26,9 @@ class GenerateMSTeamsConnectCodeRequest extends RestfulRequest {
 
 	// generate and save a login code for the requested email address
 	async updateUserSignupToken () {
-		const signupTokens = new SignupTokens({ api: this.api });
-		signupTokens.initialize();
-
 		// replace the hyphens with nothing as it makes copy/pasting easier
 		const tenantToken = UUID().replace(/-/g, '');
-		await signupTokens.insert(tenantToken, this.user.id, {
+		await this.api.services.signupTokens.insert(tenantToken, this.user.id, {
 			expiresIn: 600000,
 			more: {
 				teamIds: this.user.get('teamIds') || []

--- a/api_server/modules/users/generate_msteams_connect_code.js
+++ b/api_server/modules/users/generate_msteams_connect_code.js
@@ -1,0 +1,81 @@
+// handle the "POST /no-auth/msteams-connect-code" request to have a login code sent to
+// user's email address
+
+'use strict';
+
+const RestfulRequest = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/util/restful/restful_request.js');
+const LoginCodeHelper = require('./login_code_helper');
+
+class GenerateMSTeamsConnectCodeRequest extends RestfulRequest {
+
+	async authorize () {
+		// no pre-authorization needed
+	}
+
+	async process () {
+		await this.requireAndAllow(); // require certain parameters, and discard unknown parameters
+		await this.updateUserCode(); // generate and save a login code for the requested email address
+	}
+
+	async handleResponse () {
+        this.responseData = {
+            connectCode: this.codeData.loginCode
+        };
+
+        await super.handleResponse();
+	}
+
+	// require certain parameters, and discard unknown parameters
+	async requireAndAllow () {
+		[
+			'_loginCheat',
+			'_delayEmail',
+			'expiresIn'
+		].forEach(parameter => {
+			this[parameter] = this.request.body[parameter];
+			delete this.request.body[parameter];
+		});
+		await this.requireAllowParameters('body', {
+			required: {
+				string: ['email'],
+			},
+			optional: {
+				string: ['teamId']
+			}
+		});
+	}
+
+	// generate and save a login code for the requested email address
+	async updateUserCode () {
+		this.loginCodeHelper = new LoginCodeHelper({
+			request: this,
+			email: this.request.body.email,
+			teamId: this.request.body.teamId,
+			_delayEmail: this._delayEmail,
+			expiresIn: this.expiresIn,
+            target: "msteams"
+		});
+		this.codeData = await this.loginCodeHelper.updateUserCode();
+	}
+
+	// describe this route for help
+	static describe () {
+		return {
+			tag: 'connectCode',
+			summary: 'Generates a connect code',
+			access: 'No authorization needed',
+			description: 'Generates a code allowing a user to connect their CS account with MSTeams',
+			input: {
+				summary: 'Specify attributes in the body',
+				looksLike: {
+					'email*': '<User\'s email>'
+				},
+			},
+			errors: [
+				'parameterRequired'
+			]
+		};
+	}
+}
+
+module.exports = GenerateMSTeamsConnectCodeRequest;

--- a/api_server/modules/users/signup_tokens.js
+++ b/api_server/modules/users/signup_tokens.js
@@ -42,8 +42,15 @@ class SignupTokens {
 		else if (typeof options.secureExpiresIn === 'number') {
 			expiresIn = options.secureExpiresIn;
 		}
-		tokenData.expiresAt = Date.now() + expiresIn;
-		if (typeof options.more === 'object') {
+
+        if(typeof options.expiresAt === 'number'){
+            tokenData.expiresAt = options.expiresAt;
+        }
+        else{
+            tokenData.expiresAt = Date.now() + expiresIn;
+        }
+
+        if (typeof options.more === 'object') {
 			Object.assign(tokenData, options.more);
 		}
 		if (options.isInviteCode) {

--- a/api_server/modules/users/users.js
+++ b/api_server/modules/users/users.js
@@ -207,6 +207,12 @@ const USERS_ADDITIONAL_ROUTES = [
 		path: '/web/join-company/:id',
 		requestClass: require('./web_join_company_request')
 	}
+	},
+    {
+        method: 'post',
+        path: 'no-auth/msteams-connect-code',
+        requestClass: require('./generate_msteams_connect_code')
+    }
 ];
 
 class Users extends Restful {

--- a/api_server/modules/users/users.js
+++ b/api_server/modules/users/users.js
@@ -206,13 +206,12 @@ const USERS_ADDITIONAL_ROUTES = [
 		method: 'put',
 		path: '/web/join-company/:id',
 		requestClass: require('./web_join_company_request')
-	}
 	},
-    {
-        method: 'post',
-        path: 'msteams/generate-connect-code',
-        requestClass: require('./generate_msteams_connect_code')
-    }
+	{
+		method: 'post',
+		path: 'msteams/generate-connect-code',
+		requestClass: require('./generate_msteams_connect_code')
+	}
 ];
 
 class Users extends Restful {

--- a/api_server/modules/users/users.js
+++ b/api_server/modules/users/users.js
@@ -210,7 +210,7 @@ const USERS_ADDITIONAL_ROUTES = [
 	},
     {
         method: 'post',
-        path: 'no-auth/msteams-connect-code',
+        path: 'msteams/generate-connect-code',
         requestClass: require('./generate_msteams_connect_code')
     }
 ];

--- a/shared/server_utils/custom_config.js
+++ b/shared/server_utils/custom_config.js
@@ -313,16 +313,13 @@ module.exports = function customConfigFunc(nativeCfg) {
 		asana: {},
 		bitbucket: {},
 		azuredevops: {},
-		fossa: {},
 		github: {},
 		gitlab: {},
 		jira: {},
 		linear: {},
-		msteams: {},
 		okta: {},
 		slack: {},
 		trello: {},
-        trunk: {},
 		newrelicgrok: {},
 		newRelicIdentity: {},
 		// These providers need appClientId to be defined so the api knows those providers can be configured.
@@ -339,6 +336,7 @@ module.exports = function customConfigFunc(nativeCfg) {
 		circleci: { appClientId: 'placeholder' },
 		jenkins: { appClientId: 'placeholder' },
 		trunk: { appClientId: 'placeholder' },
+		msteams: { appClientId: 'placeholder' },
 	};
 	// THIS WILL OVERWRITE CONFIG DATA IF >1 REPEATING BLOCK (installation) EXISTS FOR A GIVEN PROVIDER
 	// The plan is to remove the repeating blocks from the schema.


### PR DESCRIPTION
Adds a new route to generate (essentially) a login token, but for MSTeams connections. Need it to be returned through response and not emailed since it will be displayed inside of CS. Added an override to allow specifying the expiresAt during the insertion of a new token, because I really only want to "update" the token by adding a new prop and removing an old one (and wanted to keep the original expiresAt)


[Changes reviewed on CodeStream](https://codestream-stg.staging-service.newrelic.com/r/Ya5We-trHA5di0uy/E_nxuWj0Qra1Fx8k9Lw9-w?src=GitHub) by calvinallen on Apr 6, 2023

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>