### PR TITLE
Transition from an array of Error Group IDs to just a singular group Id

### DIFF
--- a/api_server/modules/posts/test/post_post/code_errors/nr_account_test.js
+++ b/api_server/modules/posts/test/post_post/code_errors/nr_account_test.js
@@ -22,9 +22,9 @@ class NRAccountTest extends CodeErrorTest {
 	// set the mock account IDs to use for the test
 	setMockAccountIds (callback) {
 		if (this.dontIncludeErrorGroupId) {
-			this.apiRequestOptions.headers['X-CS-Mock-Error-Group-Ids'] = "";	
+			this.apiRequestOptions.headers['X-CS-Mock-Error-Group-Id'] = "";	
 		} else {
-			this.apiRequestOptions.headers['X-CS-Mock-Error-Group-Ids'] = this.data.codeError.objectId;
+			this.apiRequestOptions.headers['X-CS-Mock-Error-Group-Id'] = this.data.codeError.objectId;
 		}
 		/*
 		const codeErrorId = this.data.codeError.accountId;


### PR DESCRIPTION
The singular `errorGroup` nerdgraph call doesn't add a timewindow like the plural `errorGroups` call does. Since we never call that with more than one errorGroupId at a time anyway, transitioned all the code and tests to that.