### PR TITLE
Add Fossa as a provider

### DIFF
--- a/api_server/modules/fossa/fossa_auth.js
+++ b/api_server/modules/fossa/fossa_auth.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const OAuthModule = require(process.env.CSSVC_BACKEND_ROOT + '/api_server/lib/oauth/oauth_module.js');
+
+const OAUTH_CONFIG = {
+	provider: 'fossa',
+	host: 'fossa.com',
+	needsConfigure: true
+};
+
+const ROUTES = [];
+
+class FossaAuth extends OAuthModule {
+
+	constructor (config) {
+		super(config);
+		this.oauthConfig = OAUTH_CONFIG;
+	}
+
+	getRoutes () {
+		return ROUTES;
+	}
+}
+
+module.exports = FossaAuth;

--- a/api_server/modules/fossa/module.js
+++ b/api_server/modules/fossa/module.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./fossa_auth.js');

--- a/api_server/modules/providers/provider_test_constants.js
+++ b/api_server/modules/providers/provider_test_constants.js
@@ -214,6 +214,13 @@ const STANDARD_PROVIDER_HOSTS = {
 		isEnterprise: false,
 		host: 'trunk.io',
 		needsConfigure: false
+	},
+	"fossa*com": {
+		id:'fossa*com',
+		name: 'fossa',
+		isEnterprise: false,
+		host: 'fossa.com',
+		needsConfigure: true
 	}
 };
 

--- a/shared/server_utils/custom_config.js
+++ b/shared/server_utils/custom_config.js
@@ -313,6 +313,7 @@ module.exports = function customConfigFunc(nativeCfg) {
 		asana: {},
 		bitbucket: {},
 		azuredevops: {},
+		fossa: {},
 		github: {},
 		gitlab: {},
 		jira: {},
@@ -328,6 +329,7 @@ module.exports = function customConfigFunc(nativeCfg) {
 		// Their respective APIs do not require a client ID so they're not actually used.
 		youtrack: { appClientId: 'placeholder' },
 		bitbucket_server: { appClientId: 'placeholder' },
+		fossa: { appClientId: 'placeholder' },
 		github_enterprise: { appClientId: 'placeholder' },
 		gitlab_enterprise: { appClientId: 'placeholder' },
 		jiraserver: { appClientId: 'placeholder' },
@@ -439,6 +441,7 @@ module.exports = function customConfigFunc(nativeCfg) {
 		'azuredevops',
 		'bitbucket',
 		'bitbucket_server',
+		'fossa',
 		'github',
 		'github_enterprise',
 		'gitlab',


### PR DESCRIPTION
Task: https://issues.newrelic.com/browse/NR-119842

In order for the front end to connect to Fossa, we have to add Fossa as a provider to the server. It adds a new Auth file for Fossa, and adds Fossa into existing configuration files. 

Thanks Calvin for all your help with this change!
