### PR TITLE
Update links

### DIFF
--- a/api_server/etc/msteamsbot/eu/manifest.json
+++ b/api_server/etc/msteamsbot/eu/manifest.json
@@ -8,9 +8,9 @@
 	"developer": {
 		"name": "CodeStream",
 		"mpnId": "",
-		"websiteUrl": "https://www.codestream.com",
-		"privacyUrl": "https://www.codestream.com/privacy",
-		"termsOfUseUrl": "https://www.codestream.com/terms"
+		"websiteUrl": "https://newrelic.com/codestream",
+		"privacyUrl": "https://newrelic.com/termsandconditions/privacy",
+		"termsOfUseUrl": "https://newrelic.com/termsandconditions/terms"
 	},
 	"description": {
 		"short": "CodeStream is an extension to your IDE that works with your existing tools.",

--- a/api_server/etc/msteamsbot/template/manifest.json
+++ b/api_server/etc/msteamsbot/template/manifest.json
@@ -6,9 +6,9 @@
     "packageName": "codestream.codestream{{env}}",
     "developer": {
         "name": "CodeStream{{env}}",
-        "websiteUrl": "https://www.codestream.com",
-        "privacyUrl": "https://www.codestream.com/privacy",
-        "termsOfUseUrl": "https://www.codestream.com/terms"
+        "websiteUrl": "https://newrelic.com/codestream",
+        "privacyUrl": "https://newrelic.com/termsandconditions/privacy",
+        "termsOfUseUrl": "https://newrelic.com/termsandconditions/terms"
     },
     "icons": {
         "color": "color.png",

--- a/api_server/modules/providers/msteams_conversation_bot.js
+++ b/api_server/modules/providers/msteams_conversation_bot.js
@@ -17,7 +17,7 @@ const {
 
 const PERSONAL_BOT_MESSAGE = 'Please run this command from your personal bot chat.';
 const TEAM_BOT_MESSAGE = 'Please run this command from a team channel.';
-// const HELP_URL = 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/';
+// const HELP_URL = 'https://docs.newrelic.com/docs/codestream/code-discussion/msteams-integration/';
 // Keys of properties used to store
 const STATE_PROPERTY_WELCOMED_USER = 'welcomedUser';
 const STATE_PROPERTY_CODESTREAM_USER_ID = 'codestreamUserId';
@@ -616,7 +616,7 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 					{
 						type: 'Action.OpenUrl',
 						title: 'Sign up',
-						url: 'https://www.codestream.com',
+						url: 'https://newrelic.com/codestream',
 						iconUrl: OPEN_EXTERNAL_LINK_ICON,
 					},
 				],
@@ -671,13 +671,13 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 					{
 						type: 'Action.OpenUrl',
 						title: 'Detailed Instructions',
-						url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
+						url: 'https://docs.newrelic.com/docs/codestream/code-discussion/msteams-integration/',
 						iconUrl: OPEN_EXTERNAL_LINK_ICON,
 					},
 					{
 						type: 'Action.OpenUrl',
 						title: 'Download CodeStream',
-						url: 'https://www.codestream.com',
+						url: 'https://newrelic.com/codestream',
 						iconUrl: OPEN_EXTERNAL_LINK_ICON,
 					},
 				],
@@ -791,13 +791,13 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 					{
 						type: 'Action.OpenUrl',
 						title: 'Detailed Instructions',
-						url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
+						url: 'https://docs.newrelic.com/docs/codestream/code-discussion/msteams-integration/',
 						iconUrl: OPEN_EXTERNAL_LINK_ICON,
 					},
 					{
 						type: 'Action.OpenUrl',
 						title: 'Download CodeStream',
-						url: 'https://www.codestream.com',
+						url: 'https://newrelic.com/codestream',
 						iconUrl: OPEN_EXTERNAL_LINK_ICON,
 					},
 				],
@@ -886,13 +886,13 @@ class MSTeamsConversationBot extends TeamsActivityHandler {
 					{
 						type: 'Action.OpenUrl',
 						title: 'Detailed Instructions',
-						url: 'https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/',
+						url: 'https://docs.newrelic.com/docs/codestream/code-discussion/msteams-integration/',
 						iconUrl: OPEN_EXTERNAL_LINK_ICON,
 					},
 					{
 						type: 'Action.OpenUrl',
 						title: 'Download CodeStream',
-						url: 'https://www.codestream.com',
+						url: 'https://newrelic.com/codestream',
 						iconUrl: OPEN_EXTERNAL_LINK_ICON,
 					},
 				],

--- a/api_server/modules/providers/slack_interactive_component_blocks.js
+++ b/api_server/modules/providers/slack_interactive_component_blocks.js
@@ -14,7 +14,7 @@ class SlackInteractiveComponentBlocks {
 						text: 'Sign Up',
 						emoji: true
 					},
-					url: 'https://codestream.com',
+					url: 'https://newrelic.com/codestream',
 					value: 'click_me_123'
 				}
 			}

--- a/api_server/modules/web/templates/signed_in.hbs
+++ b/api_server/modules/web/templates/signed_in.hbs
@@ -17,7 +17,7 @@
 
 <body>
 	<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-		<a class="navbar-brand" href="https://codestream.com">
+		<a class="navbar-brand" href="https://newrelic.com/codestream">
 			<img alt="CodeStream" class="logo" src="https://images.codestream.com/logos/cs-banner-1764x272.png" />
 		</a>
 	</nav>


### PR DESCRIPTION
Updated some references to codestream.com. There are a ton in there, but I only updated the ones that seemed relevant, which wasn't many.

Also updated the link to the MS Teams integration help page, which is getting a new home.