### PR TITLE
Update gif on error redirect page

### DIFF
--- a/api_server/modules/web/templates/partial_launcher_detailed.hbs
+++ b/api_server/modules/web/templates/partial_launcher_detailed.hbs
@@ -683,7 +683,7 @@ function onIdeSelected(e, moniker) {
 			</div>
 		</div>
 		<div class="video-wrapper">
-			<img class="observability-gif" src="https://docs.newrelic.com/static/codestream_screenshot-full_error-comment-animation-5bcd43b92edf2771af5ab32af765bd86.gif" alt="CodeStream Observability" /> 
+			<img class="observability-gif" src="https://raw.githubusercontent.com/TeamCodeStream/CodeStream/develop/images/animated/ErrorsAI-VSC.gif" alt="CodeStream Observability" /> 
 		</div>
 	</div>
 	{{/if}}


### PR DESCRIPTION
Old one got broken when I updated the docs site.